### PR TITLE
Fix countdown after searching

### DIFF
--- a/src/components/ConferenceCard.js
+++ b/src/components/ConferenceCard.js
@@ -38,7 +38,7 @@ const ConferenceCard = ({ conference }) => {
       setCountdown(calculateCountdown(conference.deadline));
     }, 1000);
     return () => clearInterval(interval);
-  }, [conference.deadline]);
+  });
 
   // Format date range or fallback
   const dateRangeDisplay = conference.date 


### PR DESCRIPTION
When searching for a conference (e.g. POPL) and then clear the search bar, the countdown of POPL will be off compared to others. This PR fixes the bug.
