### PR TITLE
Added EMNLP 2025 & ICML 2026 Conferences

### DIFF
--- a/public/data/conferences.yaml
+++ b/public/data/conferences.yaml
@@ -717,6 +717,19 @@
 ## Machine Learning
 - name: ICML
   description: International Conference on Machine Learning
+  year: 2026
+  link: http://icml.cc/Conferences/FutureMeetings
+  deadline: "2026-01-30"
+  abstract_deadline: "2026-01-23"
+  date: "2026-07-06"
+  place: Seoul, South Korea
+  acceptance_rate:
+  num_submission:
+  general_chair: 
+  program_chair:
+
+- name: ICML
+  description: International Conference on Machine Learning
   year: 2025
   link: https://icml.cc/Conferences/2025
   deadline: "2025-01-30"

--- a/public/data/conferences.yaml
+++ b/public/data/conferences.yaml
@@ -1478,6 +1478,21 @@
 
 - name: EMNLP
   description: Empirical Methods in Natural Language Processing
+  year: 2025
+  link: https://2025.emnlp.org/
+  deadline: "2025-05-19"
+  notification_date: "2025-08-20"
+  note: 
+  abstract_deadline: 
+  date: "2025-11-05"
+  place: Suzhou, China
+  acceptance_rate: 
+  num_submission: 
+  general_chair: Dirk Hovy
+  program_chair: Christos Christodoulopoulos, Tanmoy Chakraborty, Carolyn Rose, Violet Peng
+
+- name: EMNLP
+  description: Empirical Methods in Natural Language Processing
   year: 2024
   link: https://2024.emnlp.org/
   deadline: "2024-06-15"


### PR DESCRIPTION
Added EMNLP 2025 with confirmed deadline, date, location, and chairs.
Added ICML 2026 with confirmed date and location (no confirmed chairs yet).