### PR TITLE
Add LLM-based crawler with 41 conference series coverage

### DIFF
--- a/Progress_update.md
+++ b/Progress_update.md
@@ -1,0 +1,73 @@
+hey everyone! just finished building an automated crawler for csconfs and wanted to share what's working (and what's not lol)
+
+## progress so far
+basically a smart crawler that:
+- uses the conference "series homepage" (like `aaai.org`) to find next year's page
+- feeds the HTML to Google's Gemini AI to extract dates, locations, and deadlines
+- outputs suggestions to a YAML file for manual review before merging
+
+## the good stuff 
+- **coverage**: covers around **41 major series** (~55% of the dataset!)
+- **latest script run results**: found **8 new conferences** ready to add:
+  - NAACL 2026 (San Diego)
+  - SIGMOD 2027 (Huntington Beach)
+  - ICCAD 2025 (Munich)
+  - SIGMETRICS 2026 (Ann Arbor)
+  - CGO 2026 (Sydney)
+  - SIGGRAPH 2026 (LA)
+  - SIGGRAPH Asia 2026 (Kuala Lumpur)
+  - UIST 2026 (Detroit)
+- **accuracy**: added filters to prevent false positives (eg matching PDFs or journal pages, because that was an issue that kept happening)
+
+
+## some limitations
+**timing issues**
+- conferences announce their next year at different times
+- some are already planning 2027, others haven't posted 2026 yet
+- ran it today: 41 conferences checked, only 8 had new pages live
+
+**hosting chaos**
+- some conferences switch between official domains and GitHub Pages every year (for example ICDE sometimes uses icde2026.github.io and sometimes ieee-icde.org/2025, so it is very inconsistent)
+- had to exclude ICDE and VLDB because their URL patterns are too unpredictable, this will also have to be done for the conferences not yet covered by the crawler
+
+**cost/rate limits**
+- uses Gemini API ($$$) so can't run it constantly
+- has 2-sec delay between requests to be polite
+- realistically, the script should probably be ran bi-weekly or once a month
+
+**manual review required**
+- outputs to `suggested_updates_llm.yaml` instead of auto-merging
+- you still need to copy-paste into the main file
+- safer than accidentally breaking the dataset
+
+## the workflow
+```bash
+# run the crawler
+./.venv/bin/python scripts/update_confs_llm.py
+
+# review suggested_updates_llm.yaml
+# copy good entries to public/data/conferences.yaml
+```
+
+## summary
+it's not perfect but it's WAY better than manually checking 70+ conference websites every month. should save a ton of time once conferences start announcing their 2026/2027 dates 
+
+**coverage breakdown by area:**
+- **AI/ML** (6): AAAI, ICML, NeurIPS, ICLR, IJCAI, KDD
+- **Computer Vision** (5): CVPR, ICCV, ECCV, SIGGRAPH, SIGGRAPH Asia
+- **Architecture/Hardware** (6): ISCA, MICRO, HPCA, DAC, ICCAD, CGO
+- **Systems** (4): OSDI, SOSP, EuroSys, FAST
+- **Software Engineering** (3): ICSE, ISSTA, OOPSLA
+- **Databases** (2): SIGMOD, PODS
+- **Security** (2): CCS, NDSS
+- **Bioinformatics** (2): ISMB, RECOMB
+- **Theory** (2): CAV, LICS
+- **Visualization** (2): VIS, VR
+- **Networking** (2): SIGCOMM, IMC
+- **NLP** (1): NAACL
+- **Performance** (1): SIGMETRICS
+- **Robotics** (1): ICRA
+- **HCI** (1): UIST
+- **Information Retrieval** (1): SIGIR
+
+lmk if you have questions or want to expand coverage to more conferences

--- a/known_crawler_issues.md
+++ b/known_crawler_issues.md
@@ -1,0 +1,34 @@
+# Conference Crawler - Known Limitations
+
+### VLDB
+- **Problem**: Matched journal volumes instead of conference page
+- **Fix**: Temporarily removed `series_link` (2027 doesn't exist yet, last is 2026)
+
+## Improved Filters
+
+Added filtering in `find_next_year_link()` to skip:
+- File extensions: `.pdf`, `.png`, `.jpg`, `.jpeg`, `.gif`
+- Journal patterns: `journal`, `submission/`, `volumes-and-issues`
+- Supporting materials: `flyer`, `poster`, `workshop`
+- Admin pages: `/member`, `/login`, `/subscribe`
+
+## Conferences with Coverage Issues
+
+The following conferences require manual updates due to unreliable hosting patterns:
+
+### ICDE (IEEE International Conference on Data Engineering)
+- **Status**: Manual updates only
+- **Reason**: Inconsistent hosting that alternates between:
+  - Official domain: `ieee-icde.org/YYYY/` (e.g., 2025)
+  - GitHub Pages: `icdeYYYY.github.io` (e.g., 2024, 2026)
+- **Problem**: The official domain won't link to GitHub-hosted years, making auto-discovery impossible
+- **Solution**: Check conference announcements manually or monitor IEEE ICDE mailing lists
+
+### VLDB (Very Large Data Bases)
+- **Status**: Temporarily disabled
+- **Reason**: 2027 conference not announced yet (latest is 2026)
+- **Note**: Re-enable once 2027 is officially announced on `vldb.org`
+
+### Other Considerations
+- **Database conferences**: Often host content on Springer/ACM which confuses the crawler
+- **Theory conferences**: Sometimes hosted on institutional sites that change yearly

--- a/public/data/conferences.yaml
+++ b/public/data/conferences.yaml
@@ -1,4871 +1,4729 @@
-## Artificial Intelligence
 - name: AAAI
   description: AAAI Conference on Artificial Intelligence
+  series_link: https://aaai.org/conference/aaai/
   year: 2026
   link: https://aaai.org/conference/aaai/aaai-26/
-  deadline: "2025-08-01"
-  abstract_deadline: "2025-07-25"
-  notification_date: "2025-11-03"
-  date: "2026-01-20"
+  deadline: '2025-08-01'
+  abstract_deadline: '2025-07-25'
+  notification_date: '2025-11-03'
+  date: '2026-01-20'
   place: Singapore
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Sven Koenig
   program_chair: Chad Jenkins, Matthew Taylor
-
-
 - name: AAAI
   description: AAAI Conference on Artificial Intelligence
   year: 2025
   link: https://aaai.org/conference/aaai/aaai-25/
-  deadline: "2024-08-15"
-  abstract_deadline: "2024-08-07"
-  notification_date: "2024-12-09"
-  date: "2025-02-27"
+  deadline: '2024-08-15'
+  abstract_deadline: '2024-08-07'
+  notification_date: '2024-12-09'
+  date: '2025-02-27'
   place: Philadelphia, PA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Toby Walsh
   program_chair: Julie Shah, Zico Kolter
-
+  series_link: https://aaai.org/conference/aaai/
 - name: AAAI
   description: AAAI Conference on Artificial Intelligence
   year: 2024
   link: https://aaai.org/conference/aaai/aaai-24/
-  deadline: "2023-08-15"
-  abstract_deadline: "2023-08-08"
-  notification_date: "2023-12-09"
-  date: "2024-02-20"
+  deadline: '2023-08-15'
+  abstract_deadline: '2023-08-08'
+  notification_date: '2023-12-09'
+  date: '2024-02-20'
   place: Vancouver, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Michael Wooldridge
   program_chair: Jennifer Dy, Sriraam Natarajan
-
+  series_link: https://aaai.org/conference/aaai/
 - name: AAAI
   description: AAAI Conference on Artificial Intelligence
   year: 2023
   link: https://aaai-23.aaai.org/
-  deadline: "2022-08-15"
-  abstract_deadline: "2022-08-08"
-  notification_date: "2022-11-18"
-  date: "2023-02-07"
+  deadline: '2022-08-15'
+  abstract_deadline: '2022-08-08'
+  notification_date: '2022-11-18'
+  date: '2023-02-07'
   place: Washington, DC
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Brian Williams
   program_chair: Yiling Chen, Jennifer Neville
-
+  series_link: https://aaai.org/conference/aaai/
 - name: AAAI
   description: AAAI Conference on Artificial Intelligence
   year: 2022
   link: https://aaai.org/conference/aaai/aaai-22/
-  deadline: "2021-09-08"
-  abstract_deadline: "2021-08-30"
-  notification_date: "2021-11-29"
-  date: "2022-02-22"
+  deadline: '2021-09-08'
+  abstract_deadline: '2021-08-30'
+  notification_date: '2021-11-29'
+  date: '2022-02-22'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
-  general_chair: Katia Sycara 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Katia Sycara
   program_chair: Vasant Honavar, Matthijs Spaan
-
+  series_link: https://aaai.org/conference/aaai/
 - name: AAAI
   description: AAAI Conference on Artificial Intelligence
   year: 2021
   link: https://aaai.org/conference/aaai/aaai-21/
-  deadline: "2020-09-09"
-  abstract_deadline: "2020-09-01"
-  notification_date: "2020-11-30"
-  date: "2021-02-02"
+  deadline: '2020-09-09'
+  abstract_deadline: '2020-09-01'
+  notification_date: '2020-11-30'
+  date: '2021-02-02'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Qiang Yang
   program_chair: Kevin Leyton-Brown, Mausam
-
+  series_link: https://aaai.org/conference/aaai/
 - name: AAAI
   description: AAAI Conference on Artificial Intelligence
   year: 2020
   link: https://aaai.org/conference/aaai/aaai-20/
-  deadline: "2019-09-05"
-  abstract_deadline: "2019-08-30"
-  notification_date: "2019-11-10"
-  date: "2020-02-07"
+  deadline: '2019-09-05'
+  abstract_deadline: '2019-08-30'
+  notification_date: '2019-11-10'
+  date: '2020-02-07'
   place: New York, NY
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Francesca Rossi
   program_chair: Vincent Conitzer, Fei Sha
-
+  series_link: https://aaai.org/conference/aaai/
 - name: AAAI
   description: AAAI Conference on Artificial Intelligence
   year: 2019
   link: https://www.openresearch.org/wiki/AAAI_2019
-  deadline: "2018-09-05"
-  abstract_deadline: "2018-08-30"
-  notification_date: "2018-11-01"
-  date: "2019-01-27"
+  deadline: '2018-09-05'
+  abstract_deadline: '2018-08-30'
+  notification_date: '2018-11-01'
+  date: '2019-01-27'
   place: Honolulu, HI
-  acceptance_rate: 16.2 
+  acceptance_rate: 16.2
   num_submission: 7095
   general_chair: Peter Stone
   program_chair: Pascal van Hentenryck, Zhi-Hua Zhou
-
+  series_link: https://aaai.org/conference/aaai/
 - name: AAAI
   description: AAAI Conference on Artificial Intelligence
   year: 2018
   link: https://www.openresearch.org/wiki/AAAI_2018
-  deadline: "2017-09-11"
-  abstract_deadline: "2017-09-08"
-  notification_date: "2017-11-09"
-  date: "2018-02-02"
+  deadline: '2017-09-11'
+  abstract_deadline: '2017-09-08'
+  notification_date: '2017-11-09'
+  date: '2018-02-02'
   place: New Orleans, LA
   acceptance_rate: 24.6
   num_submission: 3800
   general_chair: G. Michael Youngblood, Karen Myers
   program_chair: Sheila McIlraith, Kilian Weinberger
-
+  series_link: https://aaai.org/conference/aaai/
 - name: AAAI
   description: AAAI Conference on Artificial Intelligence
   year: 2017
   link: https://www.openresearch.org/wiki/AAAI_2017
-  deadline: "2016-09-14"
-  abstract_deadline: "2016-09-09"
-  date: "2017-02-04"
+  deadline: '2016-09-14'
+  abstract_deadline: '2016-09-09'
+  date: '2017-02-04'
   place: San Francisco, CA
   acceptance_rate: 24.6 %
   num_submission: 2590
-  general_chair: 
+  general_chair: null
   program_chair: Satinder Singh, Shaul Markovitch
-
+  series_link: https://aaai.org/conference/aaai/
 - name: AAAI
   description: AAAI Conference on Artificial Intelligence
   year: 2016
   link: https://aaai.org/conference/aaai/aaai16/
-  deadline: "2015-09-15"
-  notification_date: "2015-11-06"
-  date: "2016-02-12"
+  deadline: '2015-09-15'
+  notification_date: '2015-11-06'
+  date: '2016-02-12'
   place: Phoenix, AZ
   acceptance_rate: 25.8%
   num_submission: 2132
   general_chair: Matthew E.Taylor, Gita Sukthankar
-
+  series_link: https://aaai.org/conference/aaai/
 - name: AAAI
   description: AAAI Conference on Artificial Intelligence
   year: 2015
   link: https://aaai.org/conference/aaai/aaai15/
-  deadline: "2014-09-15"
-  abstract_deadline: "2014-09-10"
-  notification_date: "2014-11-07"
-  date: "2015-01-25"
+  deadline: '2014-09-15'
+  abstract_deadline: '2014-09-10'
+  notification_date: '2014-11-07'
+  date: '2015-01-25'
   place: Austin, TX
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://aaai.org/conference/aaai/
 - name: IJCAI
   description: International Joint Conferences on Artificial Intelligence
   year: 2026
   link: https://2026.ijcai.org/
-  deadline: "2026-01-19"
-  abstract_deadline: "2026-01-12"
-  rebuttal_date: "2026-04-07"
-  notification_date: "2026-04-29"
+  deadline: '2026-01-19'
+  abstract_deadline: '2026-01-12'
+  rebuttal_date: '2026-04-07'
+  notification_date: '2026-04-29'
   note: Phase 1
-  date: "2026-08-15"
+  date: '2026-08-15'
   place: Bremen, Germany
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Francesca Toni
   program_chair: Diego Calvanese
-
+  series_link: https://www.ijcai.org/
 - name: IJCAI
   description: International Joint Conference on Artificial Intelligence
   year: 2025
   link: https://2025.ijcai.org/
-  deadline: "2025-01-23"
-  abstract_deadline: "2025-01-16"
-  notification_date: "2025-04-28"
-  date: "2025-08-16"
+  deadline: '2025-01-23'
+  abstract_deadline: '2025-01-16'
+  notification_date: '2025-04-28'
+  date: '2025-08-16'
   place: Montreal, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Shlomo Zilberstein
   program_chair: James Kwok
-
+  series_link: https://www.ijcai.org/
 - name: IJCAI
   description: International Joint Conference on Artificial Intelligence
   year: 2024
   link: https://ijcai24.org/
-  deadline: "2024-01-17"
-  abstract_deadline: "2024-01-10"
-  notification_date: "2024-04-16"
-  date: "2024-08-03"
+  deadline: '2024-01-17'
+  abstract_deadline: '2024-01-10'
+  notification_date: '2024-04-16'
+  date: '2024-08-03'
   place: Jeju, South Korea
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Chengqi Zhang
   program_chair: Kate Larson
-
+  series_link: https://www.ijcai.org/
 - name: IJCAI
   description: International Joint Conference on Artificial Intelligence
   year: 2023
   link: https://ijcai-23.org/
-  deadline: "2023-01-18"
-  abstract_deadline: "2023-01-11"
-  notification_date: "2023-04-19"
-  date: "2023-08-19"
+  deadline: '2023-01-18'
+  abstract_deadline: '2023-01-11'
+  notification_date: '2023-04-19'
+  date: '2023-08-19'
   place: Macao, South Africa
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Peter Stone
   program_chair: Edith Elkind
-
-
+  series_link: https://www.ijcai.org/
 - name: IJCAI
   description: International Joint Conference on Artificial Intelligence
   year: 2022
   link: https://ijcai-22.org/
-  deadline: "2022-01-14"
-  abstract_deadline: "2022-01-07"
-  notification_date: "2022-04-20"
-  date: "2022-07-23"
+  deadline: '2022-01-14'
+  abstract_deadline: '2022-01-07'
+  notification_date: '2022-04-20'
+  date: '2022-07-23'
   place: Vienna, Austria
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Rina Dechter
   program_chair: Luc De Raedt
-
-
+  series_link: https://www.ijcai.org/
 - name: IJCAI
   description: International Joint Conference on Artificial Intelligence
   year: 2021
   link: https://ijcai-21.org/
-  deadline: "2021-01-20"
-  abstract_deadline: "2021-01-13"
-  notification_date: "2021-04-30"
-  date: "2021-08-21"
+  deadline: '2021-01-20'
+  abstract_deadline: '2021-01-13'
+  notification_date: '2021-04-30'
+  date: '2021-08-21'
   place: Montreal, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Maria Gini
   program_chair: Zhi-Hua Zhou
-
+  series_link: https://www.ijcai.org/
 - name: IJCAI
   description: International Joint Conference on Artificial Intelligence
   year: 2020
   link: https://ijcai20.org/
-  deadline: "2020-01-21"
-  abstract_deadline: "2020-01-15"
-  notification_date: "2020-04-19"
-  date: "2021-01-07"
+  deadline: '2020-01-21'
+  abstract_deadline: '2020-01-15'
+  notification_date: '2020-04-19'
+  date: '2021-01-07'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Marie desJardins
   program_chair: Christian Bessiere
-
-
+  series_link: https://www.ijcai.org/
 - name: IJCAI
   description: International Joint Conference on Artificial Intelligence
   year: 2019
   link: https://ijcai19.org/
-  deadline: "2019-02-25"
-  abstract_deadline: "2019-02-19"
-  notification_date: "2019-05-09"
-  date: "2019-08-10"
+  deadline: '2019-02-25'
+  abstract_deadline: '2019-02-19'
+  notification_date: '2019-05-09'
+  date: '2019-08-10'
   place: Macao, China
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Thomas Eiter
   program_chair: Sarit Kraus
-
-
+  series_link: https://www.ijcai.org/
 - name: IJCAI
   description: International Joint Conference on Artificial Intelligence
   year: 2018
   link: https://www.ijcai-18.org/
-  deadline: "2018-01-31"
-  abstract_deadline: "2018-01-25"
-  notification_date: "2018-04-16"
-  date: "2018-07-13"
+  deadline: '2018-01-31'
+  abstract_deadline: '2018-01-25'
+  notification_date: '2018-04-16'
+  date: '2018-07-13'
   place: Stockholm, Sweden
   acceptance_rate: 20.5
   num_submission: 3470
   general_chair: Jeffrey S. Rosenschein
   program_chair: Jérôme Lang
-
+  series_link: https://www.ijcai.org/
 - name: IJCAI
   description: International Joint Conference on Artificial Intelligence
   year: 2017
   link: https://ijcai-17.org/
-  deadline: "2017-02-20"
-  abstract_deadline: "2017-02-16"
-  notification_date: "2017-04-23"
-  date: "2017-08-19"
+  deadline: '2017-02-20'
+  abstract_deadline: '2017-02-16'
+  notification_date: '2017-04-23'
+  date: '2017-08-19'
   place: Melbourne, Australia
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Fahiem Bacchus
   program_chair: Carles Sierra
-
+  series_link: https://www.ijcai.org/
 - name: IJCAI
   description: International Joint Conference on Artificial Intelligence
   year: 2016
   link: https://ijcai-16.org/
-  deadline: "2016-02-02"
-  abstract_deadline: "2016-01-27"
-  notification_date: "2016-04-04"
-  date: "2016-07-09"
+  deadline: '2016-02-02'
+  abstract_deadline: '2016-01-27'
+  notification_date: '2016-04-04'
+  date: '2016-07-09'
   place: New York, NY
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Gerhard Brewka
   program_chair: Subbarao Kambhampati
-
+  series_link: https://www.ijcai.org/
 - name: IJCAI
   description: International Joint Conference on Artificial Intelligence
   year: 2015
   link: https://ijcai-15.org/
-  deadline: "2015-02-12"
-  abstract_deadline: "2015-02-08"
-  notification_date: "2015-04-16"
-  date: "2015-07-25"
+  deadline: '2015-02-12'
+  abstract_deadline: '2015-02-08'
+  notification_date: '2015-04-16'
+  date: '2015-07-25'
   place: Buenos Aires, Argentina
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Michael Wooldridge
   program_chair: Qiang Yang
-
-
-## Computer Vision
-
+  series_link: https://www.ijcai.org/
 - name: CVPR
   description: Conference on Computer Vision and Pattern Recognition
+  series_link: https://cvpr.thecvf.com/
   year: 2026
   link: https://cvpr.thecvf.com/Conferences/2026
-  deadline: "2025-11-13"
-  abstract_deadline: "2025-11-06"
-  notification_date: "2026-02-20"
-  rebuttal_date: "2026-01-22"
-  date: "2026-06-03"
+  deadline: '2025-11-13'
+  abstract_deadline: '2025-11-06'
+  notification_date: '2026-02-20'
+  rebuttal_date: '2026-01-22'
+  date: '2026-06-03'
   place: Denver, CO
-  acceptance_rate:
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: CVPR
   description: Conference on Computer Vision and Pattern Recognition
   year: 2025
   link: https://cvpr.thecvf.com/Conferences/2025
-  deadline: "2024-11-14"
-  abstract_deadline: "2024-11-07"
-  notification_date: "2025-01-23"
-  date: "2025-06-11"
+  deadline: '2024-11-14'
+  abstract_deadline: '2024-11-07'
+  notification_date: '2025-01-23'
+  date: '2025-06-11'
   place: Nashville, TN
-  acceptance_rate:
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Ce Liu, Bryan Morse, Cristian Sminchisescu
-  program_chair: Phillip Isola, Hedvig Kjellström, Vincent Lepetit, Fuxin Li, Hao Su, Siyu Tang 
-
+  program_chair: Phillip Isola, Hedvig Kjellström, Vincent Lepetit, Fuxin Li, Hao
+    Su, Siyu Tang
+  series_link: https://cvpr.thecvf.com/
 - name: CVPR
   description: Conference on Computer Vision and Pattern Recognition
   year: 2024
   link: https://cvpr.thecvf.com/Conferences/2024
-  deadline: "2023-11-17"
-  abstract_deadline: "2023-11-03"
-  notification_date: "2024-02-26"
-  date: "2024-06-17"
+  deadline: '2023-11-17'
+  abstract_deadline: '2023-11-03'
+  notification_date: '2024-02-26'
+  date: '2024-06-17'
   place: Seattle, WA
-  acceptance_rate:
-  num_submission:
-  general_chair: Octavia Camps, Rita Cucchiara, Sudeep Sarkar, Walter Scheirer,Ramin Zabih
-  program_chair: Zeynep Akata, David Crandall, Ali Farhadi, Robert Pless, Imari Sato, Jianxin Wu 
-
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Octavia Camps, Rita Cucchiara, Sudeep Sarkar, Walter Scheirer,Ramin
+    Zabih
+  program_chair: Zeynep Akata, David Crandall, Ali Farhadi, Robert Pless, Imari Sato,
+    Jianxin Wu
+  series_link: https://cvpr.thecvf.com/
 - name: CVPR
   description: Conference on Computer Vision and Pattern Recognition
   year: 2023
   link: https://cvpr.thecvf.com/Conferences/2023
-  deadline: "2022-11-11"
-  abstract_deadline: "2022-11-04"
-  notification_date: "2023-02-27"
-  date: "2023-06-18"
+  deadline: '2022-11-11'
+  abstract_deadline: '2022-11-04'
+  notification_date: '2023-02-27'
+  date: '2023-06-18'
   place: Vancouver, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Michael S Brown, Fei-Fei Li, Greg Mori, Yoichi Sato
-  program_chair: Andreas Geiger, Ross Girshick, Judy Hoffman, Vladlen Koltun, Svetlana Lazebnik
-
+  program_chair: Andreas Geiger, Ross Girshick, Judy Hoffman, Vladlen Koltun, Svetlana
+    Lazebnik
+  series_link: https://cvpr.thecvf.com/
 - name: CVPR
   description: Conference on Computer Vision and Pattern Recognition
   year: 2022
   link: https://cvpr.thecvf.com/Conferences/2022
-  deadline: "2021-11-18"
-  abstract_deadline: "2021-11-09"
-  notification_date: "2022-03-02"
-  date: "2022-06-19"
+  deadline: '2021-11-18'
+  abstract_deadline: '2021-11-09'
+  notification_date: '2022-03-02'
+  date: '2022-06-19'
   place: New Orleans, LA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Rama Chellappa, Jiri Matas, Long Quan, Mubarak Shah
   program_chair: Kristin Dana, Gang Hua, Stefan Roth, Dimitris Samaras, Richa Singh
-
+  series_link: https://cvpr.thecvf.com/
 - name: CVPR
   description: Conference on Computer Vision and Pattern Recognition
   year: 2021
   link: https://cvpr2021.thecvf.com
-  deadline: "2020-11-16"
-  abstract_deadline: "2020-11-09"
-  notification_date: "2021-02-28"
-  date: "2021-06-19"
+  deadline: '2020-11-16'
+  abstract_deadline: '2020-11-09'
+  notification_date: '2021-02-28'
+  date: '2021-06-19'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Michael S. Brown, Rahul Sukthankar, Tieniu Tan, Lihi Zelnik
-  program_chair: David Forsyth, Georgia Gkioxari, Tinne Tuytelaars, Ruigang Yang, Jingyi Yu
-
+  program_chair: David Forsyth, Georgia Gkioxari, Tinne Tuytelaars, Ruigang Yang,
+    Jingyi Yu
+  series_link: https://cvpr.thecvf.com/
 - name: CVPR
   description: Conference on Computer Vision and Pattern Recognition
   year: 2020
   link: https://cvpr2020.thecvf.com
-  deadline: "2019-11-15"
-  notification_date: "2020-02-23"
-  date: "2020-06-14"
+  deadline: '2019-11-15'
+  notification_date: '2020-02-23'
+  date: '2020-06-14'
   place: Seattle, WA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Terry Boult, Gerard Medioni, Ramin Zabih
   program_chair: Ce Liu, Greg Mori, Kate Saenko, Silvio Savarese
-
+  series_link: https://cvpr.thecvf.com/
 - name: CVPR
   description: Conference on Computer Vision and Pattern Recognition
   year: 2019
   link: https://cvpr2019.thecvf.com/
-  deadline: "2018-11-16"
-  notification_date: "2019-03-02"
-  date: "2019-06-16"
+  deadline: '2018-11-16'
+  notification_date: '2019-03-02'
+  date: '2019-06-16'
   place: Long Beach, CA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Larry Davis, Philip Torr, Song-Chun Zhu
   program_chair: Abhinav Gupta, Derek Hoiem, Gang Hua, Zhuowen Tu
-
+  series_link: https://cvpr.thecvf.com/
 - name: CVPR
   description: Conference on Computer Vision and Pattern Recognition
   year: 2018
   link: https://cvpr2018.thecvf.com/
-  deadline: "2017-11-15"
-  abstract_deadline: "2017-11-08"
-  notification_date: "2018-02-28"
-  date: "2018-06-18"
+  deadline: '2017-11-15'
+  abstract_deadline: '2017-11-08'
+  notification_date: '2018-02-28'
+  date: '2018-06-18'
   place: Salt Lake City, UT
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Michael Brown, Bryan Morse, Shmuel Peleg
   program_chair: David Forsyth, Ivan Laptev, Deva Ramanan, Aude Oliva
-
- 
-
+  series_link: https://cvpr.thecvf.com/
 - name: CVPR
   description: Conference on Computer Vision and Pattern Recognition
   year: 2017
   link: https://cvpr2017.thecvf.com/
-  deadline: "2016-11-15"
-  abstract_deadline: "2016-11-15"
-  notification_date: "2017-03-03"
-  date: "2017-07-21"
+  deadline: '2016-11-15'
+  abstract_deadline: '2016-11-15'
+  notification_date: '2017-03-03'
+  date: '2017-07-21'
   place: Honolulu, HI
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Rama Chellappa, Zhengyou Zhang, Anthony Hoogs
   program_chair: Jim Rehg, Yanxi Liu, Ying Wu, Camillo Taylor
-
+  series_link: https://cvpr.thecvf.com/
 - name: CVPR
   description: Conference on Computer Vision and Pattern Recognition
   year: 2016
   link: https://cvpr2016.thecvf.com/
-  deadline: "2015-11-06"
-  abstract_deadline: "2015-11-09"
-  notification_date: "2016-03-02"
-  date: "2016-06-27"
+  deadline: '2015-11-06'
+  abstract_deadline: '2015-11-09'
+  notification_date: '2016-03-02'
+  date: '2016-06-27'
   place: Las Vegas, NV
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Ruzena Bajcsy, Fei-Fei Li, Tinne Tuytelaars
   program_chair: Lourdes Agapito, Tamara Berg, Jana Kosecka, Lihi Zelnik-Manor
-
+  series_link: https://cvpr.thecvf.com/
 - name: CVPR
   description: Conference on Computer Vision and Pattern Recognition
   year: 2015
   link: https://cvpr2015.thecvf.com/
-  deadline: "2014-11-14"
-  notification_date: "2015-03-02"
-  date: "2015-06-07"
+  deadline: '2014-11-14'
+  notification_date: '2015-03-02'
+  date: '2015-06-07'
   place: Boston, MA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Horst Bischof, David Forsyth, Cordelia Schmid, Stan Sclaroff
   program_chair: Kristen Grauman, Erik Learned-Miller, Antonio Torralba, Andrew Zisserman
-
+  series_link: https://cvpr.thecvf.com/
 - name: ECCV
   description: European Conference on Computer Vision
   year: 2026
   link: https://eccv.ecva.net/Conferences/2026
-  deadline: "2026-03-06"
-  notification_date:
-  note: 
-  date: "2026-09-08"
+  deadline: '2026-03-06'
+  notification_date: null
+  note: null
+  date: '2026-09-08'
   place: Malmo, Sweden
-  acceptance_rate:
-  num_submission:
-  general_chair: Kalle Åström, Serge Belongie, Richard Hartley, Jana Košecká, Andrea Vedaldi
-  program_chair: Zeynep Akata, Paolo Favaro, Zuzana Kukelova, Atsuto Maki, Federico Tombari 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Kalle Åström, Serge Belongie, Richard Hartley, Jana Košecká, Andrea
+    Vedaldi
+  program_chair: Zeynep Akata, Paolo Favaro, Zuzana Kukelova, Atsuto Maki, Federico
+    Tombari
+  series_link: https://eccv.ecva.net/
 - name: ECCV
   description: European Conference on Computer Vision
   year: 2024
   link: https://eccv2024.ecva.net
-  deadline: "2024-03-07"
-  abstract_deadline: "2024-02-29"
-  notificate_date: "2024-07-01"
-  date: "2024-09-29"
+  deadline: '2024-03-07'
+  abstract_deadline: '2024-02-29'
+  notificate_date: '2024-07-01'
+  date: '2024-09-29'
   place: Milan, Italy
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Andrew Fitzgibbon, Laura Leal-Taixe, Vittorio Murino
-  program_chair: Aleš Leonardis, Elisa Ricci, Stefan Roth, Olga Russakovsky, Torsten Sattler, Gül Varol 
-
-
+  program_chair: Aleš Leonardis, Elisa Ricci, Stefan Roth, Olga Russakovsky, Torsten
+    Sattler, Gül Varol
+  series_link: https://eccv.ecva.net/
 - name: ECCV
   description: European Conference on Computer Vision
   year: 2022
   link: https://eccv2022.ecva.net
-  deadline: "2022-03-07"
-  notification_date: "2022-07-03"
-  date: "2022-10-24"
+  deadline: '2022-03-07'
+  notification_date: '2022-07-03'
+  date: '2022-10-24'
   place: Tel Aviv, Israel
-  acceptance_rate:
+  acceptance_rate: null
   num_submission:
     general_chair: Rita Cucchiara, Jiri Matas, Amnon Shashua, Lihi Zelnik-Manor
   program_chair: Shai Avidan, Gabriel Brostow, Giovanni Maria Farinella, Tal Hassner
-
+  series_link: https://eccv.ecva.net/
 - name: ECCV
   description: European Conference on Computer Vision
   year: 2020
   link: https://eccv2020.eu
-  deadline: "2020-03-05"
-  abstract_deadline: "2020-02-27"
-  notification_date: "2020-07-03"
-  date: "2020-08-23"
+  deadline: '2020-03-05'
+  abstract_deadline: '2020-02-27'
+  notification_date: '2020-07-03'
+  date: '2020-08-23'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Vittorio Ferrari, Bob Fisher, Cordelia Schmid, Emanuele Trucco
   program_chair: Andrea Vedaldi, Horst Bischof, Thomas Brox, Jan-Michael Frahm
-
-
+  series_link: https://eccv.ecva.net/
 - name: ECCV
   description: European Conference on Computer Vision
   year: 2018
   link: https://eccv2018.org
-  deadline: "2018-03-14"
-  abstract_deadline: "2018-03-07"
-  date: "2018-09-08"
-  notification_date: "2018-07-03"
+  deadline: '2018-03-14'
+  abstract_deadline: '2018-03-07'
+  date: '2018-09-08'
+  notification_date: '2018-07-03'
   place: Munich, Germany
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Horst Bischof, Daniel Cremers, Bernt Schiele, Ramin Zabih
   program_chair: Vittorio Ferrari, Martial Hebert, Cristian Sminchisescu, Yair Weiss
-
+  series_link: https://eccv.ecva.net/
 - name: ECCV
   description: European Conference on Computer Vision
   year: 2016
   link: https://eccv2016.org
-  deadline: "2016-03-07"
-  abstract_deadline: "2016-02-29"
-  date: "2016-10-08"
+  deadline: '2016-03-07'
+  abstract_deadline: '2016-02-29'
+  date: '2016-10-08'
   place: Amsterdam, Netherlands
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
+  series_link: https://eccv.ecva.net/
 - name: ECCV
   description: European Conference on Computer Vision
   year: 2014
   link: http://conferences.visionbib.com/2014/eccv-9-14-call.html
-  deadline: "2014-03-14"
-  abstract_deadline: "2014-03-07"
-  notification_date: "2014-06-17"
-  date: "2014-09-06"
+  deadline: '2014-03-14'
+  abstract_deadline: '2014-03-07'
+  notification_date: '2014-06-17'
+  date: '2014-09-06'
   place: Zurich, Switzerland
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
+  series_link: https://eccv.ecva.net/
 - name: ECCV
   description: European Conference on Computer Vision
   year: 2012
   link: https://eccv2012.unifi.it/conference/important-dates/
-  deadline: "2012-03-05"
-  abstract_deadline: "2012-02-15"
-  notification_date: "2012-07-05"
-  date: "2012-10-07"
+  deadline: '2012-03-05'
+  abstract_deadline: '2012-02-15'
+  notification_date: '2012-07-05'
+  date: '2012-10-07'
   place: Florence, Italy
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Roberto Cipolla, Carlo Colombo, Alberto Del Bimbo
   program_chair: Andrew Fitzgibbon, Svetlana Lazebnik, Yoichi Sato, Cordelia Schmid
-
+  series_link: https://eccv.ecva.net/
 - name: ECCV
   description: European Conference on Computer Vision
   year: 2010
   link: https://projects.ics.forth.gr/eccv2010/dates.php
-  deadline: "2010-03-17"
-  abstract_deadline: "2010-03-07"
-  notification_date: "2010-06-10"
-  date: "2010-09-05"
+  deadline: '2010-03-17'
+  abstract_deadline: '2010-03-07'
+  notification_date: '2010-06-10'
+  date: '2010-09-05'
   place: Heraklion, Greece
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Antonis Argyros, Panos Trahanais, George Tziritas
   program_chair: Kostas Daniilidis, Petros Maragos, Nikos Paragios
-
-
+  series_link: https://eccv.ecva.net/
 - name: ECCV
   description: European Conference on Computer Vision
   year: 2008
   link: http://eccv2008.inrialpes.fr
-  deadline: "2008-03-14"
-  abstract_deadline: "2008-03-07"
-  date: "2008-10-12"
+  deadline: '2008-03-14'
+  abstract_deadline: '2008-03-07'
+  date: '2008-10-12'
   place: Marseille, France
   acceptance_rate: 27.9%
   num_submission: 871
   stats_link: http://eccv2008.inrialpes.fr/stats.html
   general_chair: Jean Ponce
   program_chair: David Forsyth, Philip Torr, Andrew Zisserman
-
+  series_link: https://eccv.ecva.net/
 - name: ECCV
   description: European Conference on Computer Vision
   year: 2006
   link: https://eccv2006.org
-  deadline: "2006-03-14"
-  abstract_deadline: "2006-03-07"
-  date: "2006-05-07"
+  deadline: '2006-03-14'
+  abstract_deadline: '2006-03-07'
+  date: '2006-05-07'
   place: Graz, Austria
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
+  series_link: https://eccv.ecva.net/
 - name: ICCV
   description: International Conference on Computer Vision
   year: 2025
   link: https://iccv.thecvf.com
-  deadline: "2025-03-07"
-  abstract_deadline: "2025-03-03"
-  notification_date: "2025-06-26" 
-  date: "2025-10-19"
+  deadline: '2025-03-07'
+  abstract_deadline: '2025-03-03'
+  notification_date: '2025-06-26'
+  date: '2025-10-19'
   place: Honolulu, Hawaii
-  acceptance_rate:
-  num_submission:
-  general_chair: Hilde Kuehne, Gerard Medioni, Dimitris Samaras, Jingyi Yu, Ramin Zabih
-  program_chair: Bohyung Han, Aniruddha Kembhavi, Richard Souvenir, Deqing Sun, Ayellet Tal, Jingdong Wang 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Hilde Kuehne, Gerard Medioni, Dimitris Samaras, Jingyi Yu, Ramin
+    Zabih
+  program_chair: Bohyung Han, Aniruddha Kembhavi, Richard Souvenir, Deqing Sun, Ayellet
+    Tal, Jingdong Wang
+  series_link: https://iccv.thecvf.com/
 - name: ICCV
   description: International Conference on Computer Vision
   year: 2023
   link: https://iccv2023.thecvf.com/
-  deadline: "2023-03-08"
-  abstract_deadline: "2023-03-01"
-  notification_date: "2023-07-13"
-  date: "2023-10-02"
+  deadline: '2023-03-08'
+  abstract_deadline: '2023-03-01'
+  notification_date: '2023-07-13'
+  date: '2023-10-02'
   place: Paris, France
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jana Kosecka, Jean Ponce, Cordelia Schmid, Andrew Zisserman
-  program_chair: Lourdes Agapito, Yasu Furukawa, Kristen Grauman, Kaiming He, Ivan Laptev
-
-
+  program_chair: Lourdes Agapito, Yasu Furukawa, Kristen Grauman, Kaiming He, Ivan
+    Laptev
+  series_link: https://iccv.thecvf.com/
 - name: ICCV
   description: International Conference on Computer Vision
   year: 2021
   link: https://iccv2021.thecvf.com/
-  deadline: "2021-03-17"
-  abstract_deadline: "2021-03-10"
-  notification_date: "2021-07-22"
-  date: "2021-10-11"
+  deadline: '2021-03-17'
+  abstract_deadline: '2021-03-10'
+  notification_date: '2021-07-22'
+  date: '2021-10-11'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: James Clark, Yasuyuki Matsushita, Camillo J. Taylor, Tamara Berg
   program_chair: Tal Hassner, Christopher Pal, Yoichi Sato, Dima Damen
-
+  series_link: https://iccv.thecvf.com/
 - name: ICCV
   description: International Conference on Computer Vision
   year: 2019
   link: https://iccv2019.thecvf.com/
-  deadline: "2019-03-22"
-  abstract_deadline: "2019-03-15"
-  notification_date: "2019-07-22"
-  date: "2019-10-27"
+  deadline: '2019-03-22'
+  abstract_deadline: '2019-03-15'
+  notification_date: '2019-07-22'
+  date: '2019-10-27'
   place: Seoul, South Korea
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Kyoung Mu Lee, David Forsyth, Marc Pollefeys, Xiaoou Tang
   program_chair: In So Kweon, Nikos Paragios, Ming-Hsuan Yang, Svetlana Lazebnik
-
+  series_link: https://iccv.thecvf.com/
 - name: ICCV
   description: International Conference on Computer Vision
   year: 2017
   link: https://iccv2017.thecvf.com/
-  deadline: "2017-03-17"
-  abstract_deadline: "2017-03-10"
-  notification_date: "2017-07-17"
-  date: "2017-10-22"
+  deadline: '2017-03-17'
+  abstract_deadline: '2017-03-10'
+  notification_date: '2017-07-17'
+  date: '2017-10-22'
   place: Venice, Italy
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Katsushi Ikeuchi, Gérard Medioni, Marcello Pelillo
   program_chair: Rita Cucchiara, Yasuyuki Matsushita, Nicu Sebe, Stefano Soatto
-
+  series_link: https://iccv.thecvf.com/
 - name: ICCV
   description: International Conference on Computer Vision
   year: 2015
   link: https://iccv2015.thecvf.com/
-  deadline: "2015-04-22"
-  abstract_deadline: "2015-04-15"
-  notification_date: "2015-09-03"
-  date: "2015-12-11"
+  deadline: '2015-04-22'
+  abstract_deadline: '2015-04-15'
+  notification_date: '2015-09-03'
+  date: '2015-12-11'
   place: Santiago, Chile
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Ruzena Bajcsy, Greg Hager, Yi Ma
   program_chair: Katsushi Ikeuchi, Christoph Schnörr, Josef Sivic, Rene Vidal
-
-## Machine Learning
+  series_link: https://iccv.thecvf.com/
 - name: ICML
   description: International Conference on Machine Learning
   year: 2026
   link: http://icml.cc/Conferences/FutureMeetings
-  deadline: "2026-01-30"
-  abstract_deadline: "2026-01-23"
-  date: "2026-07-06"
-  notificate_date:
-  rebuttal_date:
+  deadline: '2026-01-30'
+  abstract_deadline: '2026-01-23'
+  date: '2026-07-06'
+  notificate_date: null
+  rebuttal_date: null
   place: Seoul, South Korea
-  acceptance_rate:
-  num_submission:
-  general_chair: 
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://icml.cc/
 - name: ICML
   description: International Conference on Machine Learning
   year: 2025
   link: https://icml.cc/Conferences/2025
-  deadline: "2025-01-30"
-  abstract_deadline: "2025-01-23"
-  date: "2025-07-13"
+  deadline: '2025-01-30'
+  abstract_deadline: '2025-01-23'
+  date: '2025-07-13'
   place: Vancouver, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Aarti Singh
   program_chair: Maryam Fazel, Daniel Hsu, Simon Lacoste-Julien, Virginia Smith
-
+  series_link: https://icml.cc/
 - name: ICML
   description: International Conference on Machine Learning
   year: 2024
   link: https://icml.cc/Conferences/2024
-  deadline: "2024-02-01"
-  notification_date: "2024-05-01"
-  date: "2024-07-21"
+  deadline: '2024-02-01'
+  notification_date: '2024-05-01'
+  date: '2024-07-21'
   place: Vienna, Austria
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Russ Salakhutdinov
   program_chair: Katherine Heller, Zico Kolter, Nuria Oliver, Adrian Weller
-
+  series_link: https://icml.cc/
 - name: ICML
   description: International Conference on Machine Learning
   year: 2023
   link: https://icml.cc/Conferences/2023
-  deadline: "2023-01-26"
-  notification_date: "2023-04-24"
-  date: "2023-07-23"
+  deadline: '2023-01-26'
+  notification_date: '2023-04-24'
+  date: '2023-07-23'
   place: Honolulu, HI
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Andreas Krause
-  program_chair: Emma Brunskill, Kyunghyun Cho, Barbara Engelhardt 
-
+  program_chair: Emma Brunskill, Kyunghyun Cho, Barbara Engelhardt
+  series_link: https://icml.cc/
 - name: ICML
   description: International Conference on Machine Learning
   year: 2022
   link: https://icml.cc/Conferences/2022
-  deadline: "2022-01-27"
-  abstract_deadline: "2022-01-20"
-  notification_date: "2022-05-14"
-  date: "2022-07-17"
+  deadline: '2022-01-27'
+  abstract_deadline: '2022-01-20'
+  notification_date: '2022-05-14'
+  date: '2022-07-17'
   place: Baltimore, MD
-  acceptance_rate:
-  num_submission:
-  general_chair: Kamalika Chaudhuri 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Kamalika Chaudhuri
   program_chair: Stefanie Jegelka, Le Song, Csaba Szepesvari
-
+  series_link: https://icml.cc/
 - name: ICML
   description: International Conference on Machine Learning
   year: 2021
   link: https://icml.cc/Conferences/2021
-  deadline: "2021-02-04"
-  abstract_deadline: "2021-01-28"
-  notification_date: "2021-05-08"
-  date: "2021-07-18"
+  deadline: '2021-02-04'
+  abstract_deadline: '2021-01-28'
+  notification_date: '2021-05-08'
+  date: '2021-07-18'
   place: Online
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: John Langford
   program_chair: Marina Meila, Tong Zhang
-
+  series_link: https://icml.cc/
 - name: ICML
   description: International Conference on Machine Learning
   year: 2020
   link: https://icml.cc/Conferences/2020
-  deadline: "2020-02-04"
-  abstract_deadline: "2020-01-30"
-  date: "2020-07-12"
+  deadline: '2020-02-04'
+  abstract_deadline: '2020-01-30'
+  date: '2020-07-12'
   place: Online
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: David Blei
   program_chair: Hal Daumé, Aarti Singh
-
+  series_link: https://icml.cc/
 - name: ICML
   description: International Conference on Machine Learning
   year: 2019
   link: https://icml.cc/Conferences/2019
-  deadline: "2019-01-23"
-  abstract_deadline: "2019-01-16"
-  notification_date: "2019-04-24"
-  date: "2019-06-09"
+  deadline: '2019-01-23'
+  abstract_deadline: '2019-01-16'
+  notification_date: '2019-04-24'
+  date: '2019-06-09'
   place: Long Beach, CA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Eric Xing
   program_chair: Kamalika Chaudhuri, Ruslan Salakhutdinov
-
+  series_link: https://icml.cc/
 - name: ICML
   description: International Conference on Machine Learning
   year: 2018
   link: https://icml.cc/Conferences/2018
-  deadline: "2018-01-09"
-  notification_date: "2018-05-12"
-  date: "2018-07-10"
+  deadline: '2018-01-09'
+  notification_date: '2018-05-12'
+  date: '2018-07-10'
   place: Stockholm, Sweden
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Francis Bach
   program_chair: Jennifer Dy, Andreas Krause
-
+  series_link: https://icml.cc/
 - name: ICML
   description: International Conference on Machine Learning
   year: 2017
   link: https://icml.cc/Conferences/2017
-  deadline: "2017-02-02"
-  notification_date: "2017-05-13"
-  date: "2017-08-06"
+  deadline: '2017-02-02'
+  notification_date: '2017-05-13'
+  date: '2017-08-06'
   place: Sidney, Australia
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Tony Jebara
   program_chair: Doina Precup, Yee Whye Teh
- 
+  series_link: https://icml.cc/
 - name: ICML
   description: International Conference on Machine Learning
   year: 2016
   link: https://icml.cc/2016/index.html
-  deadline: "2016-02-05"
-  note: 
-  date: "2016-06-19"
+  deadline: '2016-02-05'
+  note: null
+  date: '2016-06-19'
   place: New York, NY
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: John Langford
   program_chair: Nina Balcan, Kilian Weinberger
-
+  series_link: https://icml.cc/
 - name: ICML
   description: International Conference on Machine Learning
   year: 2015
   link: https://icml.cc/2015/
-  deadline: "2015-02-06"
-  notification_date: "2015-04-24"
-  date: "2015-07-06"
+  deadline: '2015-02-06'
+  notification_date: '2015-04-24'
+  date: '2015-07-06'
   place: Lile, France
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Joelle Pineau
   program_chair: Francis Bach, David Blei
-
+  series_link: https://icml.cc/
 - name: ICLR
   description: International Conference on Learning Representations
   year: 2026
   link: https://iclr.cc/Conferences/2026
-  deadline: "2025-09-24"
-  abstract_deadline: "2025-09-19"
-  notification_date: "2025-01-22"
-  rebuttal_date: "2025-11-11"
-  date: "2026-04-23"
+  deadline: '2025-09-24'
+  abstract_deadline: '2025-09-19'
+  notification_date: '2025-01-22'
+  rebuttal_date: '2025-11-11'
+  date: '2026-04-23'
   place: Rio de Janeiro, Brazil
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: TBD
   program_chair: TBD
-
-
+  series_link: https://iclr.cc/
 - name: ICLR
   description: International Conference on Learning Representations
   year: 2025
   link: https://iclr.cc/Conferences/2025
-  deadline: "2024-10-01"
-  abstract_deadline: "2024-09-24"
-  notification_date: "2025-01-22"
-  date: "2025-04-24"
+  deadline: '2024-10-01'
+  abstract_deadline: '2024-09-24'
+  notification_date: '2025-01-22'
+  date: '2025-04-24'
   place: Singapore
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Yisong Yue
   program_chair: Animesh Garg, Nanyun (Violet) Peng, Fei Sha
-
+  series_link: https://iclr.cc/
 - name: ICLR
   description: International Conference on Learning Representations
   year: 2024
   link: https://iclr.cc/Conferences/2024
-  deadline: "2023-09-28"
-  abstract_deadline: "2023-09-23"
-  date: "2024-05-07"
+  deadline: '2023-09-28'
+  abstract_deadline: '2023-09-23'
+  date: '2024-05-07'
   place: Vienna, Austria
-  acceptance_rate:
-  num_submission:
-  general_chair: Been Kim 
-  program_chair: Swarat Chaudhuri, Katerina Fragkiadaki, Mohammad Emtiyaz Khan, Yizhou Sun 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Been Kim
+  program_chair: Swarat Chaudhuri, Katerina Fragkiadaki, Mohammad Emtiyaz Khan, Yizhou
+    Sun
+  series_link: https://iclr.cc/
 - name: ICLR
   description: International Conference on Learning Representations
   year: 2023
   link: https://iclr.cc/Conferences/2023
-  deadline: "2022-09-28"
-  abstract_deadline: "2022-09-21"
-  notification_date: "2023-01-21"
-  date: "2023-05-01"
+  deadline: '2022-09-28'
+  abstract_deadline: '2022-09-21'
+  notification_date: '2023-01-21'
+  date: '2023-05-01'
   place: Kigali, Rwanda
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Yan Liu
   program_chair: Maximilian Nickel, Mengdi Wang, Nancy F Chen, Vukosi Marivate
-
+  series_link: https://iclr.cc/
 - name: ICLR
   description: International Conference on Learning Representations
   year: 2022
   link: https://iclr.cc/Conferences/2022
-  deadline: "2021-10-06"
-  abstract_deadline: "2021-09-29"
-  notification_date: "2022-01-24"
-  date: "2022-04-25"
+  deadline: '2021-10-06'
+  abstract_deadline: '2021-09-29'
+  notification_date: '2022-01-24'
+  date: '2022-04-25'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Katja Hofmann
   program_chair: Chelsea Finn, Yejin Choi, Marc Deisenroth
-
+  series_link: https://iclr.cc/
 - name: ICLR
   description: International Conference on Learning Representations
   year: 2021
   link: https://iclr.cc/Conferences/2021
-  deadline: "2020-10-02"
-  abstract_deadline: "2020-09-25"
-  notification_date: "2021-01-14"
-  date: "2021-05-03"
+  deadline: '2020-10-02'
+  abstract_deadline: '2020-09-25'
+  notification_date: '2021-01-14'
+  date: '2021-05-03'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Shakir Mohamed
   program_chair: Katja Hofmann
-
+  series_link: https://iclr.cc/
 - name: ICLR
   description: International Conference on Learning Representations
   year: 2020
   link: https://iclr.cc/Conferences/2020
-  deadline: "2019-09-25"
-  notification_date: "2019-12-19"
-  date: "2020-04-26"
+  deadline: '2019-09-25'
+  notification_date: '2019-12-19'
+  date: '2020-04-26'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Alexander Rush
   program_chair: Shakir Mohamed
-
+  series_link: https://iclr.cc/
 - name: ICLR
   description: International Conference on Learning Representations
   year: 2019
   link: https://iclr.cc/Conferences/2019
-  deadline: "2018-09-27"
-  date: "2019-05-06"
+  deadline: '2018-09-27'
+  date: '2019-05-06'
   place: New Orleans, LA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Tara Sainath
   program_chair: Sergey Levine, Karen Livescu, Shakir Mohamed
-
+  series_link: https://iclr.cc/
 - name: ICLR
   description: International Conference on Learning Representations
   year: 2018
   link: https://iclr.cc/Conferences/2018
-  deadline: "2017-10-27"
-  notification_date: "2018-01-29"
-  date: "2018-04-30"
+  deadline: '2017-10-27'
+  notification_date: '2018-01-29'
+  date: '2018-04-30'
   place: Vancouver, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Yoshua Bengio, Yann LeCun
   program_chair: Tara Sainath
-
+  series_link: https://iclr.cc/
 - name: ICLR
   description: International Conference on Learning Representations
   year: 2017
   link: https://iclr.cc/archive/www/2017.html
-  deadline: "2017-10-27"
-  date: "2017-04-24"
+  deadline: '2017-10-27'
+  date: '2017-04-24'
   place: Toulon, France
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Yoshua Bengio, Yann LeCun
   program_chair: Marc1Aurelio Ranzato
-
+  series_link: https://iclr.cc/
 - name: ICLR
   description: International Conference on Learning Representations
   year: 2016
   link: https://iclr.cc/archive/www/2016.html
-  deadline: "2015-11-19"
-  abstract_deadline: "2015-11-12"
-  date: "2016-05-02"
+  deadline: '2015-11-19'
+  abstract_deadline: '2015-11-12'
+  date: '2016-05-02'
   place: San Juan, PR
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Yoshua Bengio, Yann LeCun
   program_chair: Hugo Larochell
-
-
+  series_link: https://iclr.cc/
 - name: ICLR
   description: International Conference on Learning Representations
   year: 2015
   link: https://iclr.cc/archive/www/doku.php%3Fid=iclr2015:main.html
-  deadline: "2014-12-19"
-  notification_date: "2015-03-20"
-  date: "2015-05-07"
+  deadline: '2014-12-19'
+  notification_date: '2015-03-20'
+  date: '2015-05-07'
   place: San Diego, CA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Yoshua Bengio, Yann LeCun
   program_chair: Brian Kingsbury, Hugo Larochelle, Samy Bengio, Nando de Freitas
-
+  series_link: https://iclr.cc/
 - name: KDD
   description: ACM SIGKDD Conference on Knowledge Discovery and Data Mining
   year: 2026
   link: https://kdd2026.kdd.org/
-  abstract_deadline: "2025-07-24"
-  deadline: "2025-07-31"
-  date: "2026-08-09"
+  abstract_deadline: '2025-07-24'
+  deadline: '2025-07-31'
+  date: '2026-08-09'
   place: Jeju, Korea
-  rebuttal_date: "2025-10-04"
-  notificate_date: "2025-11-23"
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
+  rebuttal_date: '2025-10-04'
+  notificate_date: '2025-11-23'
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://kdd.org/
 - name: KDD
   description: ACM SIGKDD Conference on Knowledge Discovery and Data Mining
   year: 2025
   link: https://kdd2025.kdd.org/
-  abstract_deadline: "2024-08-01"
-  deadline: "2024-08-08"
+  abstract_deadline: '2024-08-01'
+  deadline: '2024-08-08'
   note: Cycle 1/2
-  date: "2025-08-03"
+  date: '2025-08-03'
   place: Toronto, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Luiza Antonie, Jian Pei, Xiaohui Yu
   program_chair: Flavio Chierichetti, Hady W. Lauw, Yizhou Sun, Srinivasan Parthasarathy
-
+  series_link: https://kdd.org/
 - name: KDD
   description: ACM SIGKDD Conference on Knowledge Discovery and Data Mining
   year: 2025
   link: https://kdd2025.kdd.org/
-  abstract_deadline: "2025-02-03"
-  deadline: "2025-02-10"
+  abstract_deadline: '2025-02-03'
+  deadline: '2025-02-10'
   note: Cycle 2/2
-  date: "2025-08-03"
+  date: '2025-08-03'
   place: Toronto, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Luiza Antonie, Jian Pei, Xiaohui Yu
   program_chair: Flavio Chierichetti, Hady W. Lauw, Yizhou Sun, Srinivasan Parthasarathy
-
-
+  series_link: https://kdd.org/
 - name: KDD
   description: ACM SIGKDD Conference on Knowledge Discovery and Data Mining
   year: 2024
   link: https://kdd2024.kdd.org/
-  deadline: "2024-02-08"
-  abstract_deadline: "2024-02-01"
-  date: "2024-08-25"
+  deadline: '2024-02-08'
+  abstract_deadline: '2024-02-01'
+  date: '2024-08-25'
   place: Barcelona, Spain
   note: Cycle 1/2
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Ricardo Baeza-Yates, Francesco Bonchi
   program_chair: Flavio Chierichetti, Danai Koutra, Ravi Kumar
-
+  series_link: https://kdd.org/
 - name: KDD
   description: ACM SIGKDD Conference on Knowledge Discovery and Data Mining
   year: 2024
   link: https://kdd2024.kdd.org/
-  deadline: "2024-08-08"
-  abstract_deadline: "2024-08-01"
-  date: "2024-08-25"
+  deadline: '2024-08-08'
+  abstract_deadline: '2024-08-01'
+  date: '2024-08-25'
   place: Barcelona, Spain
   note: Cycle 2/2
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Ricardo Baeza-Yates, Francesco Bonchi
   program_chair: Flavio Chierichetti, Danai Koutra, Ravi Kumar
-
+  series_link: https://kdd.org/
 - name: KDD
   description: ACM SIGKDD Conference on Knowledge Discovery and Data Mining
   year: 2023
   link: https://kdd.org/kdd2023/
-  deadline: "2023-02-02"
-  date: "2023-08-06"
+  deadline: '2023-02-02'
+  date: '2023-08-06'
   place: Long Beach, CA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Ambuj Singh, Yizhou Sun
   program_chair: Xifeng Yan, Leman Akoglu, Dimitrios Gunopulos
-
+  series_link: https://kdd.org/
 - name: KDD
   description: ACM SIGKDD Conference on Knowledge Discovery and Data Mining
   year: 2022
   link: https://kdd.org/kdd2022/
-  deadline: "2022-02-10"
-  date: "2022-08-14"
+  deadline: '2022-02-10'
+  date: '2022-08-14'
   place: Washington, DC
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Aidong Zhang, Huzefa Rangwala
   program_chair: Nitesh Chawla, Yan Liu
-
+  series_link: https://kdd.org/
 - name: KDD
   description: ACM SIGKDD Conference on Knowledge Discovery and Data Mining
   year: 2021
   link: https://www.kdd.org/kdd2021/
-  deadline: "2021-02-08"
+  deadline: '2021-02-08'
   place: Virtual Conference
-  date: "2021-08-14"
-  acceptance_rate:
-  num_submission:
+  date: '2021-08-14'
+  acceptance_rate: null
+  num_submission: null
   general_chair: Feida Zhu, Beng Chin Ooi, Chunyan Miao
   program_chair: Wynne Hsu, Sanjay Chawla
-
+  series_link: https://kdd.org/
 - name: KDD
   description: ACM SIGKDD Conference on Knowledge Discovery and Data Mining
   year: 2020
   link: https://www.kdd.org/kdd2020/
-  deadline: "2020-02-13"
-  date: "2020-08-23"
+  deadline: '2020-02-13'
+  date: '2020-08-23'
   place: Online
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Rajesh Gupta, Yan Liu
   program_chair: Wei Wang, Heng Huang
-
+  series_link: https://kdd.org/
 - name: KDD
   description: ACM SIGKDD Conference on Knowledge Discovery and Data Mining
   year: 2019
   link: https://www.kdd.org/kdd2019/
-  deadline: "2019-02-03"
-  date: "2019-08-04"
+  deadline: '2019-02-03'
+  date: '2019-08-04'
   place: Anchorage, AK
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Vipin Kumar, Ankur Teredesai
   program_chair: George Karypis, Evimaria Terzi, Ying Li, Romer Rosales
-
+  series_link: https://kdd.org/
 - name: KDD
   description: ACM SIGKDD Conference on Knowledge Discovery and Data Mining
   year: 2018
   link: https://www.kdd.org/kdd2018/
-  deadline: "2018-02-11"
-  date: "2018-08-19"
+  deadline: '2018-02-11'
+  date: '2018-08-19'
   place: London, United Kingdom
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Yike Guo, Faisal Farooq
   program_chair: Chih-Jen Lin, Hui Xiong
-
+  series_link: https://kdd.org/
 - name: KDD
   description: ACM SIGKDD Conference on Knowledge Discovery and Data Mining
   year: 2017
   link: https://www.kdd.org/kdd2017/
-  deadline: "2017-02-17"
-  date: "2017-08-13"
+  deadline: '2017-02-17'
+  date: '2017-08-13'
   place: Halifax, Nova Scotia, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Stan Matwin, Shipeng Yu
   program_chair: Ravi Kumar, Tina Eliassi-Rad
-
+  series_link: https://kdd.org/
 - name: KDD
   description: ACM SIGKDD Conference on Knowledge Discovery and Data Mining
   year: 2016
   link: https://www.kdd.org/kdd2016/
-  deadline: "2016-02-12"
-  date: "2016-08-13"
+  deadline: '2016-02-12'
+  date: '2016-08-13'
   place: San Francisco, CA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Balaji Krishnapuram, Mohak Shah
   program_chair: Alex Smola, Charu Aggarwal
-
+  series_link: https://kdd.org/
 - name: KDD
   description: ACM SIGKDD Conference on Knowledge Discovery and Data Mining
   year: 2015
   link: https://www.kdd.org/kdd2015/
-  deadline: "2015-02-20"
-  date: "2015-08-10"
+  deadline: '2015-02-20'
+  date: '2015-08-10'
   place: Sydney, Australia
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Longbing Cao, Changqi Zhang
   program_chair: Thorsten Joachims, Geoff Webb
-
-
+  series_link: https://kdd.org/
 - name: NeurIPS
   description: Neural Information Processing Systems
   year: 2025
   link: https://neurips.cc/Conferences/2025
-  deadline: "2025-05-15"
-  notification_date: "2025-09-18"
-  abstract_deadline: "2025-05-11"
-  date: "2025-12-02"
+  deadline: '2025-05-15'
+  notification_date: '2025-09-18'
+  abstract_deadline: '2025-05-11'
+  date: '2025-12-02'
   place: San Diego, CA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Danielle Belgrave, Cheng Zhang
   program_chair: Nancy Chen, Marzyeh Ghassemi, Piotr Koniusz, Razvan Pascanu
-
+  series_link: https://neurips.cc/
 - name: NeurIPS
   description: Neural Information Processing Systems
   year: 2024
   link: https://neurips.cc/Conferences/2024
-  deadline: "2024-05-22"
-  abstract_deadline: "2024-05-15"
-  notification_date: "2024-09-26"
-  date: "2024-12-10"
+  deadline: '2024-05-22'
+  abstract_deadline: '2024-05-15'
+  notification_date: '2024-09-26'
+  date: '2024-12-10'
   place: Vancouver, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Amir Globerson, Lester Mackey
-  program_chair: Angela Fan, Ulrich Paquet, Jakub Tomczak, Cheng Zhang 
-
+  program_chair: Angela Fan, Ulrich Paquet, Jakub Tomczak, Cheng Zhang
+  series_link: https://neurips.cc/
 - name: NeurIPS
   description: Neural Information Processing Systems
   year: 2023
   link: https://neurips.cc/Conferences/2023
-  deadline: "2023-05-17"
-  abstract_deadline: "2023-05-11"
-  notification_date: "2023-09-22"
-  date: "2023-12-10"
+  deadline: '2023-05-17'
+  abstract_deadline: '2023-05-11'
+  notification_date: '2023-09-22'
+  date: '2023-12-10'
   place: New Orleans, LA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Tristan Naumann, Alice Oh
   program_chair: Amir Globerson, Moritz Hardt, Sergey Levine, Kate Saenko
-
+  series_link: https://neurips.cc/
 - name: NeurIPS
   description: Neural Information Processing Systems
   year: 2022
   link: https://neurips.cc/Conferences/2022
-  deadline: "2022-05-19"
-  abstract_deadline: "2022-05-16"
-  notification_date: "2022-09-14"
-  date: "2022-11-28"
+  deadline: '2022-05-19'
+  abstract_deadline: '2022-05-16'
+  notification_date: '2022-09-14'
+  date: '2022-11-28'
   place: New Orleans, LA
-  acceptance_rate:
-  num_submission:
-  general_chair: Sanmi Koyejo, Shakir Mohamed 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Sanmi Koyejo, Shakir Mohamed
   program_chair: Alekh Agarwal, Danielle Belgrave, Kyunghyun Cho
-
+  series_link: https://neurips.cc/
 - name: NeurIPS
   description: Neural Information Processing Systems
   year: 2021
   link: https://neurips.cc/Conferences/2021
-  deadline: "2021-05-28"
-  abstract_deadline: "2021-05-21"
-  notification_date: "2021-09-28"
-  date: "2021-12-06"
+  deadline: '2021-05-28'
+  abstract_deadline: '2021-05-21'
+  notification_date: '2021-09-28'
+  date: '2021-12-06'
   place: Online
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Marc'Aurelio Ranzato
   program_chair: Alina Beygelzimer
-
+  series_link: https://neurips.cc/
 - name: NeurIPS
   description: Neural Information Processing Systems
   year: 2020
   link: https://neurips.cc/Conferences/2020
-  deadline: "2020-06-05"
-  abstract_deadline: "2020-05-27"
-  notification_date: "2020-09-26"
-  date: "2020-12-06"
+  deadline: '2020-06-05'
+  abstract_deadline: '2020-05-27'
+  notification_date: '2020-09-26'
+  date: '2020-12-06'
   place: Online
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Hugo Larochelle
   program_chair: Marc'Aurelio Ranzato
-
+  series_link: https://neurips.cc/
 - name: NeurIPS
   description: Neural Information Processing Systems
   year: 2019
   link: https://neurips.cc/Conferences/2019
-  deadline: "2019-05-23"
-  abstract_deadline: "2019-05-16"
-  notification_date: "2019-09-04"
-  date: "2019-12-08"
+  deadline: '2019-05-23'
+  abstract_deadline: '2019-05-16'
+  notification_date: '2019-09-04'
+  date: '2019-12-08'
   place: Vancouver, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Hanna Wallach
   program_chair: Hugo Larochelle
-
+  series_link: https://neurips.cc/
 - name: NeurIPS
   description: Neural Information Processing Systems
   year: 2018
   link: https://neurips.cc/Conferences/2018
-  deadline: "2018-05-18"
-  notification_date: "2018-09-05"
-  date: "2018-12-02"
+  deadline: '2018-05-18'
+  notification_date: '2018-09-05'
+  date: '2018-12-02'
   place: Montreal, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Samy Bengio
   program_chair: Hanna Wallach
-
+  series_link: https://neurips.cc/
 - name: NeurIPS
   description: Neural Information Processing Systems
   year: 2017
   link: https://neurips.cc/Conferences/2017
-  deadline: "2017-05-19"
-  notification_date: "2017-09-04"
-  date: "2017-12-04"
+  deadline: '2017-05-19'
+  notification_date: '2017-09-04'
+  date: '2017-12-04'
   place: Long Beach, CA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Isabelle Guyon, Ulrike von Luxburg
   program_chair: Samy Bengio
-
+  series_link: https://neurips.cc/
 - name: NeurIPS
   description: Neural Information Processing Systems
   year: 2016
   link: https://neurips.cc/Conferences/2016
-  deadline: "2016-05-20"
-  date: "2016-12-05"
+  deadline: '2016-05-20'
+  date: '2016-12-05'
   place: Barcelona, Spain
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Daniel D Lee, Masashi Sugiyama
   program_chair: Ulrike von Luxburg, Isabelle Guyon
-
+  series_link: https://neurips.cc/
 - name: NeurIPS
   description: Neural Information Processing Systems
   year: 2015
   link: https://neurips.cc/Conferences/2015
-  deadline: "2015-06-05"
-  date: "2015-12-07"
+  deadline: '2015-06-05'
+  date: '2015-12-07'
   place: Montreal, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Corinna Cortes, Neil D Lawrence
   program_chair: Daniel D Lee, Masashi Sugiyama
-
-## Natural Language Processing
-
+  series_link: https://neurips.cc/
 - name: ACL
   description: Annual Meeting of the Association for Computational Linguistics
   year: 2026
   link: https://2026.aclweb.org/
-  deadline: 
-  note: 
-  abstract_deadline: 
-  date: "2026-07-02"
-  place: 
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  deadline: null
+  note: null
+  abstract_deadline: null
+  date: '2026-07-02'
+  place: null
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: ACL
   description: Annual Meeting of the Association for Computational Linguistics
   year: 2025
   link: https://2025.aclweb.org/
-  deadline: "2025-02-15"
-  note: 
-  abstract_deadline: 
-  date: "2025-07-27"
+  deadline: '2025-02-15'
+  note: null
+  abstract_deadline: null
+  date: '2025-07-27'
   place: Vienna, Austria
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Roberto Navigli
   program_chair: Wanxiang Che, Joyce Nabende, Mohammad Taher Pilehvar, Ekaterina Shutova
-
 - name: ACL
   description: Annual Meeting of the Association for Computational Linguistics
   year: 2024
   link: https://2024.aclweb.org/
-  deadline: "2024-02-15"
-  note: 
-  abstract_deadline: 
-  date: "2024-08-11"
+  deadline: '2024-02-15'
+  note: null
+  abstract_deadline: null
+  date: '2024-08-11'
   place: Bangkok, Thailand
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Claire Gardent
   program_chair: Lun-Wei Ku, André Martins, Vivek Srikumar
-
 - name: ACL
   description: Annual Meeting of the Association for Computational Linguistics
   year: 2023
   link: https://2023.aclweb.org/
-  deadline: "2023-01-20"
-  note: 
-  abstract_deadline: "2023-01-13"
-  date: "2023-07-09"
+  deadline: '2023-01-20'
+  note: null
+  abstract_deadline: '2023-01-13'
+  date: '2023-07-09'
   place: Toronto, Canada
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Yang Liu
   program_chair: Jordan Boyd-Graber, Naoaki Okazaki, Anna Rogers
-
 - name: ACL
   description: Annual Meeting of the Association for Computational Linguistics
   year: 2022
   link: https://2022.aclweb.org/
-  deadline: "2022-01-15"
-  note: 
-  abstract_deadline: 
-  date: "2022-05-22"
+  deadline: '2022-01-15'
+  note: null
+  abstract_deadline: null
+  date: '2022-05-22'
   place: Dublin, Ireland
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Bernardo Magnini
   program_chair: Smaranda Muresan, Preslav Nakov, Aline Villavicencio
-
 - name: ACL
   description: Annual Meeting of the Association for Computational Linguistics
   year: 2021
   link: https://2021.aclweb.org/
-  deadline: "2021-02-01"
-  note: 
-  abstract_deadline: 
-  date: "2021-08-01"
+  deadline: '2021-02-01'
+  note: null
+  abstract_deadline: null
+  date: '2021-08-01'
   place: Bangkok, Thailand
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Chengqing Zong
   program_chair: Fei Xia, Wenjie Li, Roberto Navigli
-
 - name: ACL
   description: Annual Meeting of the Association for Computational Linguistics
   year: 2020
   link: https://acl2020.org/
-  deadline: "2019-12-09"
-  note: 
-  abstract_deadline: 
-  date: "2020-07-05"
+  deadline: '2019-12-09'
+  note: null
+  abstract_deadline: null
+  date: '2020-07-05'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Dan Jurafsky
   program_chair: Joyce Chai, Natalie Schluter, Joel Tetreault
-
 - name: ACL
   description: Annual Meeting of the Association for Computational Linguistics
   year: 2019
   link: https://acl2019.org/
-  deadline: "2019-03-04"
-  note: 
-  abstract_deadline: 
-  date: "2019-07-28"
+  deadline: '2019-03-04'
+  note: null
+  abstract_deadline: null
+  date: '2019-07-28'
   place: Florence, Italy
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Lluís Màrquez
   program_chair: Anna Korhonen, David Traum
-
 - name: ACL
   description: Annual Meeting of the Association for Computational Linguistics
   year: 2018
   link: https://acl2018.org/
-  deadline: "2018-02-22"
-  note: 
-  abstract_deadline: 
-  date: "2018-07-15"
+  deadline: '2018-02-22'
+  note: null
+  abstract_deadline: null
+  date: '2018-07-15'
   place: Melbourne, Australia
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Claire Cardie
   program_chair: Iryna Gurevych, Yusuke Miyao
-
 - name: ACL
   description: Annual Meeting of the Association for Computational Linguistics
   year: 2017
   link: http://acl2017.org/
-  deadline: "2017-02-06"
-  note: 
-  abstract_deadline: 
-  date: "2017-07-30"
+  deadline: '2017-02-06'
+  note: null
+  abstract_deadline: null
+  date: '2017-07-30'
   place: Vancouver, Canada
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Chris Callison-Burch
   program_chair: Regina Barzilay, Min-Yen Kan
-
 - name: ACL
   description: Annual Meeting of the Association for Computational Linguistics
   year: 2016
   link: https://acl2016.org/
-  deadline: "2016-03-18"
-  note: 
-  abstract_deadline: 
-  date: "2016-08-07"
+  deadline: '2016-03-18'
+  note: null
+  abstract_deadline: null
+  date: '2016-08-07'
   place: Berlin, Germany
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Antal van den Bosch
   program_chair: Katrin Erk, Noah Smith
-
 - name: EMNLP
   description: Empirical Methods in Natural Language Processing
   year: 2025
   link: https://2025.emnlp.org/
-  deadline: "2025-05-19"
-  notification_date: "2025-08-20"
-  note: 
-  abstract_deadline: 
-  date: "2025-11-05"
+  deadline: '2025-05-19'
+  notification_date: '2025-08-20'
+  note: null
+  abstract_deadline: null
+  date: '2025-11-05'
   place: Suzhou, China
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Dirk Hovy
-  program_chair: Christos Christodoulopoulos, Tanmoy Chakraborty, Carolyn Rose, Violet Peng
-
+  program_chair: Christos Christodoulopoulos, Tanmoy Chakraborty, Carolyn Rose, Violet
+    Peng
 - name: EMNLP
   description: Empirical Methods in Natural Language Processing
   year: 2024
   link: https://2024.emnlp.org/
-  deadline: "2024-06-15"
-  note: 
-  abstract_deadline: 
-  date: "2024-11-12"
+  deadline: '2024-06-15'
+  note: null
+  abstract_deadline: null
+  date: '2024-11-12'
   place: Miami, FL
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Thamar Solorio
   program_chair: Mohit Bansal, Yun-Nung (Vivian) Chen, Yaser Alonaizan
-
 - name: EMNLP
   description: Empirical Methods in Natural Language Processing
   year: 2023
   link: https://2023.emnlp.org/
-  deadline: "2023-06-23"
-  note: 
-  abstract_deadline: "2023-06-16"
-  date: "2023-12-06"
+  deadline: '2023-06-23'
+  note: null
+  abstract_deadline: '2023-06-16'
+  date: '2023-12-06'
   place: Singapore
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Yuji Matsumoto
   program_chair: Houda Bouamor, Juan Pino, Kalika Bali
-
 - name: EMNLP
   description: Empirical Methods in Natural Language Processing
   year: 2022
   link: https://2022.emnlp.org/
-  deadline: "2022-06-17"
-  note: 
-  abstract_deadline: "2022-06-10"
-  date: "2022-12-07"
+  deadline: '2022-06-17'
+  note: null
+  abstract_deadline: '2022-06-10'
+  date: '2022-12-07'
   place: Abu Dhabi, UAE
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Noah Smith
   program_chair: Yoav Goldberg, Yulia Tsvetkov
-
 - name: EMNLP
   description: Empirical Methods in Natural Language Processing
   year: 2021
   link: https://2021.emnlp.org/
-  deadline: "2021-05-17"
-  note: 
-  abstract_deadline: "2021-05-10"
-  date: "2021-11-07"
+  deadline: '2021-05-17'
+  note: null
+  abstract_deadline: '2021-05-10'
+  date: '2021-11-07'
   place: Punta Cana, Dominican Republic
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Marie-Francine Moens
   program_chair: Xuanjing Huang, Lucia Specia, Scott Wen-tau Yih
-
 - name: EMNLP
   description: Empirical Methods in Natural Language Processing
   year: 2020
   link: https://2020.emnlp.org/
-  deadline: "2020-06-26"
-  note: 
-  abstract_deadline: "2020-06-19"
-  date: "2020-11-16"
+  deadline: '2020-06-26'
+  note: null
+  abstract_deadline: '2020-06-19'
+  date: '2020-11-16'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Bonnie Webber
   program_chair: Trevor Cohn, Yulan He, Yang Liu
-
 - name: EMNLP
   description: Empirical Methods in Natural Language Processing
   year: 2019
   link: https://2019.emnlp.org/
-  deadline: "2019-05-31"
-  note: 
-  abstract_deadline: "2019-05-24"
-  date: "2019-11-03"
+  deadline: '2019-05-31'
+  note: null
+  abstract_deadline: '2019-05-24'
+  date: '2019-11-03'
   place: Hong Kong
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Kentaro Inui
   program_chair: Jing Jiang, Vincent Ng, Xiaojun Wan
-
 - name: EMNLP
   description: Empirical Methods in Natural Language Processing
   year: 2018
   link: https://emnlp2018.org/
-  deadline: "2018-05-22"
-  note: 
-  date: "2018-10-31"
+  deadline: '2018-05-22'
+  note: null
+  date: '2018-10-31'
   place: Brussels, Belgium
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Ellen Riloff
   program_chair: David Chiang, Julia Hockenmaier, Junichi Tsujii
-
 - name: EMNLP
   description: Empirical Methods in Natural Language Processing
   year: 2017
   link: https://www.aclweb.org/portal/content/emnlp-2017-call-system-demonstrations
-  deadline: "2017-04-17"
-  note: 
-  date: "2017-09-07"
+  deadline: '2017-04-17'
+  note: null
+  date: '2017-09-07'
   place: Copenhagen, Denmark
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Martha Palmer
   program_chair: Sebastian Riedel, Rebecca Hwa
-
 - name: EMNLP
   description: Empirical Methods in Natural Language Processing
   year: 2016
   link: https://www.aclweb.org/mirror/emnlp2016/call.html
-  deadline: "2016-06-03"
-  note: 
-  date: "2016-11-01"
+  deadline: '2016-06-03'
+  note: null
+  date: '2016-11-01'
   place: Austin, TX
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jian Su
   program_chair: Kevin Duh, Xavier Carreras
-
 - name: EMNLP
   description: Empirical Methods in Natural Language Processing
   year: 2015
   link: https://www.aclweb.org/portal/content/emnlp-2015
-  deadline: "2015-05-31"
-  note: 
-  date: "2015-09-17"
+  deadline: '2015-05-31'
+  note: null
+  date: '2015-09-17'
   place: Lisbon, Portugal
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Lluís Màrquez
   program_chair: Chris Callison-Burch, Jian Su
-
-
 - name: NAACL
-  description: Annual Conference of the North American Chapter of the Association for Computational Linguistics
+  description: Annual Conference of the North American Chapter of the Association
+    for Computational Linguistics
   year: 2025
   link: https://2025.naacl.org/
-  deadline: "2024-10-15"
-  note: 
-  date: "2025-04-29"
+  deadline: '2024-10-15'
+  note: null
+  date: '2025-04-29'
   place: Albuquerque, NM
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Colin Cherry
   program_chair: Lu Wang, Alan Ritter, Luis Chiruzzo
-
+  series_link: https://naacl.org/
 - name: NAACL
-  description: Annual Conference of the North American Chapter of the Association for Computational Linguistics
+  description: Annual Conference of the North American Chapter of the Association
+    for Computational Linguistics
   year: 2024
   link: https://2024.naacl.org/
-  deadline: "2023-12-15"
-  note: 
-  abstract_deadline: "2023-12-08"
-  date: "2024-06-16"
+  deadline: '2023-12-15'
+  note: null
+  abstract_deadline: '2023-12-08'
+  date: '2024-06-16'
   place: Mexico City, Mexico
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Katrin Erk
   program_chair: Kevin Duh, Helena Gómez-Adorno, Steven Bethard
-
+  series_link: https://naacl.org/
 - name: NAACL
-  description: Annual Conference of the North American Chapter of the Association for Computational Linguistics
+  description: Annual Conference of the North American Chapter of the Association
+    for Computational Linguistics
   year: 2022
   link: https://2022.naacl.org/
-  deadline: "2022-01-15"
-  note: 
-  date: "2022-07-10"
+  deadline: '2022-01-15'
+  note: null
+  date: '2022-07-10'
   place: Seattle, WA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Dan Roth
   program_chair: Marine Carpuat, Marie-Catherine de Marneffe, Ivan Vladimir Meza-Ruiz
-
+  series_link: https://naacl.org/
 - name: NAACL
-  description: Annual Conference of the North American Chapter of the Association for Computational Linguistics
+  description: Annual Conference of the North American Chapter of the Association
+    for Computational Linguistics
   year: 2021
   link: https://2021.naacl.org/
-  deadline: "2020-11-23"
-  note: 
-  date: "2021-06-06"
+  deadline: '2020-11-23'
+  note: null
+  date: '2021-06-06'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Kristina Toutanova
   program_chair: Anna Rumshisky, Luke Zettlemoyer, Dilek Hakkani-Tur
-
+  series_link: https://naacl.org/
 - name: NAACL
-  description: Annual Conference of the North American Chapter of the Association for Computational Linguistics
+  description: Annual Conference of the North American Chapter of the Association
+    for Computational Linguistics
   year: 2019
   link: https://naacl.org/naacl-hlt-2019/
-  deadline: "2018-12-10"
-  note: 
-  abstract_deadline: "2018-12-03"
-  date: "2019-06-02"
+  deadline: '2018-12-10'
+  note: null
+  abstract_deadline: '2018-12-03'
+  date: '2019-06-02'
   place: Minneapolis, MN
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jill Burstein
   program_chair: Christy Doran, Ted Pedersen, Thamar Solorio
-
+  series_link: https://naacl.org/
 - name: NAACL
-  description: Annual Conference of the North American Chapter of the Association for Computational Linguistics
+  description: Annual Conference of the North American Chapter of the Association
+    for Computational Linguistics
   year: 2018
   link: https://naacl.org/naacl-hlt-2018/
-  deadline: "2017-12-15"
-  note: 
-  abstract_deadline: "2017-12-08"
-  date: "2018-06-01"
+  deadline: '2017-12-15'
+  note: null
+  abstract_deadline: '2017-12-08'
+  date: '2018-06-01'
   place: New Orleans, LA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Marilyn Walker
   program_chair: Heng Ji, Amanda Stent
-
+  series_link: https://naacl.org/
 - name: NAACL
-  description: Annual Conference of the North American Chapter of the Association for Computational Linguistics
+  description: Annual Conference of the North American Chapter of the Association
+    for Computational Linguistics
   year: 2016
   link: https://naacl.org/naacl-hlt-2016/
-  deadline: "2016-01-06"
-  note: 
-  abstract_deadline: "2015-12-08"
-  date: "2016-06-12"
+  deadline: '2016-01-06'
+  note: null
+  abstract_deadline: '2015-12-08'
+  date: '2016-06-12'
   place: San Diego, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Kevin Knight
   program_chair: Ani Nenkova, Owen Rambow
-
+  series_link: https://naacl.org/
 - name: NAACL
-  description: Annual Conference of the North American Chapter of the Association for Computational Linguistics
+  description: Annual Conference of the North American Chapter of the Association
+    for Computational Linguistics
   year: 2015
   link: https://naacl.org/naacl-hlt-2015/
-  deadline: "2014-12-04"
-  note: 
-  date: "2015-05-31"
+  deadline: '2014-12-04'
+  note: null
+  date: '2015-05-31'
   place: Denver, CO
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Rada Mihalcea
   program_chair: Joyce Chai, Anoop Sarkar
-
-# The Web and Information Retrieval
+  series_link: https://naacl.org/
 - name: SIGIR
-  description: International ACM SIGIR Conference on Research and Development in Information Retrieval
+  description: International ACM SIGIR Conference on Research and Development in Information
+    Retrieval
   year: 2025
   link: https://sigir2025.dei.unipd.it/
-  deadline: "2025-01-23"
-  note: 
-  abstract_deadline: "2025-01-16"
-  date: "2025-07-13"
+  deadline: '2025-01-23'
+  note: null
+  abstract_deadline: '2025-01-16'
+  date: '2025-07-13'
   place: Padua, Italy
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Nicola Ferro, Maria Maistro, Gabriella Pasi
   program_chair: Omar Alonso, Andrew Trotman, Suzan Verberne
-
+  series_link: https://sigir.org/
 - name: SIGIR
-  description: International ACM SIGIR Conference on Research and Development in Information Retrieval
+  description: International ACM SIGIR Conference on Research and Development in Information
+    Retrieval
   year: 2024
   link: https://sigir-2024.github.io/
-  deadline: "2024-01-25"
-  note: 
-  abstract_deadline: "2024-01-18"
-  date: "2024-07-14"
+  deadline: '2024-01-25'
+  note: null
+  abstract_deadline: '2024-01-18'
+  date: '2024-07-14'
   place: Washington, DC
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Grace Hui Yang, Hongning Wang, Sam Han
   program_chair: Claudia Hauff, Guido Zuccon, Yi Zhang
-
+  series_link: https://sigir.org/
 - name: SIGIR
-  description: International ACM SIGIR Conference on Research and Development in Information Retrieval
+  description: International ACM SIGIR Conference on Research and Development in Information
+    Retrieval
   year: 2023
   link: https://sigir.org/sigir2023/
-  deadline: "2023-01-31"
-  note: 
-  abstract_deadline: "2023-01-24"
-  date: "2023-07-23"
+  deadline: '2023-01-31'
+  note: null
+  abstract_deadline: '2023-01-24'
+  date: '2023-07-23'
   place: Taipei, Taiwan
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Hsin-Hsi Chen, Wei-Jou (Edward) Duh, Hen-Hsen Huang
   program_chair: Makoto P. Kato, Josiane Mothe, Barbara Poblete
-
+  series_link: https://sigir.org/
 - name: SIGIR
-  description: International ACM SIGIR Conference on Research and Development in Information Retrieval
+  description: International ACM SIGIR Conference on Research and Development in Information
+    Retrieval
   year: 2022
   link: https://sigir.org/sigir2022/
-  deadline: "2022-01-28"
-  note: 
-  abstract_deadline: "2022-01-21"
-  date: "2022-07-11"
+  deadline: '2022-01-28'
+  note: null
+  abstract_deadline: '2022-01-21'
+  date: '2022-07-11'
   place: Madrid, Spain
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Enrique Amigó, Pablo Castells, Julio Gonzalo
   program_chair: Ben Carterette, Shane Culpepper, Gabriella Kazai
-
+  series_link: https://sigir.org/
 - name: SIGIR
-  description: International ACM SIGIR Conference on Research and Development in Information Retrieval
+  description: International ACM SIGIR Conference on Research and Development in Information
+    Retrieval
   year: 2021
   link: https://sigir.org/sigir2021/
-  deadline: "2021-02-09"
-  note: 
-  abstract_deadline: "2021-02-02"
-  date: "2021-07-11"
+  deadline: '2021-02-09'
+  note: null
+  abstract_deadline: '2021-02-02'
+  date: '2021-07-11'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Fernando Diaz, Chirag Shah, Torsten Suel
   program_chair: Pablo Castells, Rosie Jones, Tetsuya Sakai
-
+  series_link: https://sigir.org/
 - name: SIGIR
-  description: International ACM SIGIR Conference on Research and Development in Information Retrieval
+  description: International ACM SIGIR Conference on Research and Development in Information
+    Retrieval
   year: 2020
   link: https://sigir.org/sigir2020/
-  deadline: "2020-01-22"
-  note: 
-  abstract_deadline: "2020-01-14"
-  date: "2020-07-25"
+  deadline: '2020-01-22'
+  note: null
+  abstract_deadline: '2020-01-14'
+  date: '2020-07-25'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Yi Chang, Xueqi Cheng, Jimmy Huang
   program_chair: Jaap Kamps, Vanessa Murdock, Ji-Rong Wen
-
+  series_link: https://sigir.org/
 - name: SIGIR
-  description: International ACM SIGIR Conference on Research and Development in Information Retrieval
+  description: International ACM SIGIR Conference on Research and Development in Information
+    Retrieval
   year: 2019
   link: https://sigir.org/sigir2019/
-  deadline: "2019-01-28"
-  note: 
-  abstract_deadline: "2019-01-21"
-  date: "2019-07-21"
+  deadline: '2019-01-28'
+  note: null
+  abstract_deadline: '2019-01-21'
+  date: '2019-07-21'
   place: Paris, France
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Benjamin Piwowarski, Max Chevalier, Éric Gaussier
   program_chair: Yoelle Maarek, Jian-Yun Nie, Falk Scholer
-
+  series_link: https://sigir.org/
 - name: SIGIR
-  description: International ACM SIGIR Conference on Research and Development in Information Retrieval
+  description: International ACM SIGIR Conference on Research and Development in Information
+    Retrieval
   year: 2018
   link: https://sigir.org/sigir2018/
-  deadline: "2018-01-29"
-  note: 
-  abstract_deadline: "2018-01-22"
-  date: "2018-07-08"
+  deadline: '2018-01-29'
+  note: null
+  abstract_deadline: '2018-01-22'
+  date: '2018-07-08'
   place: Ann Arbor, MI
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Kevyn Collins-Thompson, Qiaozhu Mei
   program_chair: Brian D. Davison, Yiqun Liu, Emine Yilmaz
-
+  series_link: https://sigir.org/
 - name: SIGIR
-  description: International ACM SIGIR Conference on Research and Development in Information Retrieval
+  description: International ACM SIGIR Conference on Research and Development in Information
+    Retrieval
   year: 2017
   link: https://sigir.org/sigir2017/
-  deadline: "2017-01-24"
-  note: 
-  abstract_deadline: "2017-01-17"
-  date: "2017-08-07"
+  deadline: '2017-01-24'
+  note: null
+  abstract_deadline: '2017-01-17'
+  date: '2017-08-07'
   place: Tokyo, Japan
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Noriko Kando, Tetsuya Sakai, Hideo Joho
   program_chair: Ryen W. White, Hang Li, Arjen P. de Vries
-
+  series_link: https://sigir.org/
 - name: SIGIR
-  description: International ACM SIGIR Conference on Research and Development in Information Retrieval
+  description: International ACM SIGIR Conference on Research and Development in Information
+    Retrieval
   year: 2016
   link: https://sigir.org/sigir2016/
-  deadline: "2016-01-25"
-  note: 
-  abstract_deadline: "2016-01-18"
-  date: "2016-07-17"
+  deadline: '2016-01-25'
+  note: null
+  abstract_deadline: '2016-01-18'
+  date: '2016-07-17'
   place: Pisa, Italy
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Raffaele Perego, Fabrizio Sebastiani
   program_chair: Diane Kelly, Evangelos Kanoulas, Emine Yilmaz
-
+  series_link: https://sigir.org/
 - name: WWW
   description: The Web Conference (formerly International World Wide Web Conference)
   year: 2026
   link: https://www2026.thewebconf.org/
-  deadline: "2025-10-07"
-  note: 
-  notification_date: "2026-01-13"
-  rebuttal_date: "2025-11-24"
-  abstract_deadline: "2025-09-30"
-  date: "2026-04-13"
+  deadline: '2025-10-07'
+  note: null
+  notification_date: '2026-01-13'
+  rebuttal_date: '2025-11-24'
+  abstract_deadline: '2025-09-30'
+  date: '2026-04-13'
   place: Dubai, United Arab Emirates
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: WWW
   description: The Web Conference (formerly International World Wide Web Conference)
   year: 2025
   link: https://www2025.thewebconf.org/
-  deadline: "2024-10-14"
-  note: 
-  abstract_deadline: "2024-10-07"
-  date: "2025-04-28"
+  deadline: '2024-10-14'
+  note: null
+  abstract_deadline: '2024-10-07'
+  date: '2025-04-28'
   place: Singapore
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: WWW
   description: The Web Conference (formerly International World Wide Web Conference)
   year: 2024
   link: https://www2024.thewebconf.org/
-  deadline: "2023-10-12"
-  note: 
-  abstract_deadline: "2023-10-05"
-  date: "2024-05-13"
+  deadline: '2023-10-12'
+  note: null
+  abstract_deadline: '2023-10-05'
+  date: '2024-05-13'
   place: Singapore
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: WWW
   description: The Web Conference (formerly International World Wide Web Conference)
   year: 2023
   link: https://www2023.thewebconf.org/
-  deadline: "2022-10-13"
-  note: 
-  abstract_deadline: "2022-10-06"
-  date: "2023-04-30"
+  deadline: '2022-10-13'
+  note: null
+  abstract_deadline: '2022-10-06'
+  date: '2023-04-30'
   place: Austin, TX
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: WWW
   description: The Web Conference (formerly International World Wide Web Conference)
   year: 2022
   link: https://www2022.thewebconf.org/
-  deadline: "2021-10-15"
-  note: 
-  abstract_deadline: "2021-10-08"
-  date: "2022-04-25"
+  deadline: '2021-10-15'
+  note: null
+  abstract_deadline: '2021-10-08'
+  date: '2022-04-25'
   place: Lyon, France
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: WWW
   description: The Web Conference (formerly International World Wide Web Conference)
   year: 2021
   link: https://www2021.thewebconf.org/
-  deadline: "2020-10-15"
-  note: 
-  abstract_deadline: "2020-10-08"
-  date: "2021-04-19"
+  deadline: '2020-10-15'
+  note: null
+  abstract_deadline: '2020-10-08'
+  date: '2021-04-19'
   place: Ljubljana, Slovenia
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: WWW
   description: The Web Conference (formerly International World Wide Web Conference)
   year: 2020
   link: https://www2020.thewebconf.org/
-  deadline: "2019-10-14"
-  note: 
-  abstract_deadline: "2019-10-07"
-  date: "2020-04-20"
+  deadline: '2019-10-14'
+  note: null
+  abstract_deadline: '2019-10-07'
+  date: '2020-04-20'
   place: Taipei, Taiwan
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: WWW
   description: The Web Conference (formerly International World Wide Web Conference)
   year: 2019
   link: https://www2019.thewebconf.org/
-  deadline: "2018-10-15"
-  note: 
-  abstract_deadline: "2018-10-08"
-  date: "2019-05-13"
+  deadline: '2018-10-15'
+  note: null
+  abstract_deadline: '2018-10-08'
+  date: '2019-05-13'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: WWW
   description: The Web Conference (formerly International World Wide Web Conference)
   year: 2018
   link: https://www2018.thewebconf.org/
-  deadline: "2017-10-31"
-  note: 
-  abstract_deadline: "2017-10-26"
-  date: "2018-04-23"
+  deadline: '2017-10-31'
+  note: null
+  abstract_deadline: '2017-10-26'
+  date: '2018-04-23'
   place: Lyon, France
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: WWW
   description: The Web Conference (formerly International World Wide Web Conference)
   year: 2017
   link: http://www.wikicfp.com/cfp/servlet/event.showcfp?eventid=56073
-  deadline: "2016-10-24"
-  note: 
-  abstract_deadline: "2016-10-19"
-  date: "2017-04-03"
+  deadline: '2016-10-24'
+  note: null
+  abstract_deadline: '2016-10-19'
+  date: '2017-04-03'
   place: Perth, Australia
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: WWW
   description: The Web Conference (formerly International World Wide Web Conference)
   year: 2016
   link: https://www2016.thewebconf.org/
-  deadline: "2015-10-15"
-  note: 
-  abstract_deadline: "2015-10-08"
-  date: "2016-04-11"
+  deadline: '2015-10-15'
+  note: null
+  abstract_deadline: '2015-10-08'
+  date: '2016-04-11'
   place: Montréal, Canada
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
-
-# Systems
-
-## Computer Architecture 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: ASPLOS
   description: Architectural Support for Programming Languages and Operating Systems
   year: 2026
   link: https://www.asplos-conference.org/asplos2026/
-  deadline: "2025-08-20"
-  notification_date: "2025-11-24"
-  abstract_deadline: "2025-08-13"
-  note: "Cycle 2/2"
-  date: "2026-03-22"
+  deadline: '2025-08-20'
+  notification_date: '2025-11-24'
+  abstract_deadline: '2025-08-13'
+  note: Cycle 2/2
+  date: '2026-03-22'
   place: Pittsburgh, PA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Xulong Tang, Vijaykrishnan Narayanan
   program_chair: Benjamin C. Lee, Harry Xu, Mark Silberstein
-
 - name: ASPLOS
   description: Architectural Support for Programming Languages and Operating Systems
   year: 2026
   link: https://www.asplos-conference.org/asplos2026/
-  deadline: "2025-03-12"
-  notification_date: "2025-06-24"
-  abstract_deadline: "2025-03-05"
-  note: "Cycle 1/2"
-  date: "2026-03-22"
+  deadline: '2025-03-12'
+  notification_date: '2025-06-24'
+  abstract_deadline: '2025-03-05'
+  note: Cycle 1/2
+  date: '2026-03-22'
   place: Pittsburgh, PA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Xulong Tang, Vijaykrishnan Narayanan
   program_chair: Benjamin C. Lee, Harry Xu, Mark Silberstein
-
 - name: ASPLOS
   description: Architectural Support for Programming Languages and Operating Systems
   year: 2025
   link: https://www.asplos-conference.org/asplos2025/
-  deadline: "2024-03-01"
-  notification_date: "2024-06-10"
-  abstract_deadline: "2024-02-23"
-  note: "Cycle 3/3"
-  date: "2025-03-30"
+  deadline: '2024-03-01'
+  notification_date: '2024-06-10'
+  abstract_deadline: '2024-02-23'
+  note: Cycle 3/3
+  date: '2025-03-30'
   place: Rotterdam, Netherlands
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
 - name: ASPLOS
   description: Architectural Support for Programming Languages and Operating Systems
   year: 2025
   link: https://www.asplos-conference.org/asplos2025/
-  deadline: "2024-06-24"
-  notification_date: "2024-10-02"
-  abstract_deadline: "2024-06-17"
-  note: "Cycle 2/3"
-  date: "2025-03-30"
+  deadline: '2024-06-24'
+  notification_date: '2024-10-02'
+  abstract_deadline: '2024-06-17'
+  note: Cycle 2/3
+  date: '2025-03-30'
   place: Rotterdam, Netherlands
-  acceptance_rate:
-  num_submission:
-
-
+  acceptance_rate: null
+  num_submission: null
 - name: ASPLOS
   description: Architectural Support for Programming Languages and Operating Systems
   year: 2025
   link: https://www.asplos-conference.org/asplos2025/
-  deadline: "2024-10-18"
-  notification_date: "2025-01-27"
-  note: "Cycle 1/3"
-  date: "2025-03-30"
+  deadline: '2024-10-18'
+  notification_date: '2025-01-27'
+  note: Cycle 1/3
+  date: '2025-03-30'
   place: Rotterdam, Netherlands
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
 - name: ASPLOS
   description: Architectural Support for Programming Languages and Operating Systems
   year: 2024
   link: https://www.asplos-conference.org/asplos2024/
-  deadline: "2023-11-30"
-  date: "2024-04-27"
-  note: "Cycle 3/3"
+  deadline: '2023-11-30'
+  date: '2024-04-27'
+  note: Cycle 3/3
   place: San Diego, CA
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
 - name: ASPLOS
   description: Architectural Support for Programming Languages and Operating Systems
   year: 2024
   link: https://www.asplos-conference.org/asplos2024/
-  deadline: "2023-08-10"
-  note: "Cycle 2/3"
-  date: "2024-04-27"
+  deadline: '2023-08-10'
+  note: Cycle 2/3
+  date: '2024-04-27'
   place: San Diego, CA
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
 - name: ASPLOS
   description: Architectural Support for Programming Languages and Operating Systems
   year: 2024
   link: https://www.asplos-conference.org/asplos2024/
-  deadline: "2023-11-24"
-  notification_date: "2023-08-02"
-  note: "Cycle 1/3"
-  date: "2024-04-27"
+  deadline: '2023-11-24'
+  notification_date: '2023-08-02'
+  note: Cycle 1/3
+  date: '2024-04-27'
   place: San Diego, CA
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
 - name: ASPLOS
   description: Architectural Support for Programming Languages and Operating Systems
   year: 2023
   link: https://www.asplos-conference.org/asplos2023/
-  deadline: "2022-03-31"
-  abstract_deadline: "2022-03-24"
-  date: "2023-03-25"
+  deadline: '2022-03-31'
+  abstract_deadline: '2022-03-24'
+  date: '2023-03-25'
   place: Vancouver, Canada
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
 - name: ASPLOS
   description: Architectural Support for Programming Languages and Operating Systems
   year: 2022
   link: https://www.asplos-conference.org/asplos2022/
-  deadline: "2021-08-13"
-  date: "2022-02-28"
+  deadline: '2021-08-13'
+  date: '2022-02-28'
   place: Lausanne, Switzerland
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
 - name: ASPLOS
   description: Architectural Support for Programming Languages and Operating Systems
   year: 2021
   link: https://www.asplos-conference.org/asplos2021/
-  deadline: "2020-08-21"
-  abstract_deadline: "2020-08-14"
-  date: "2021-04-19"
+  deadline: '2020-08-21'
+  abstract_deadline: '2020-08-14'
+  date: '2021-04-19'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
 - name: ASPLOS
   description: Architectural Support for Programming Languages and Operating Systems
   year: 2020
   link: https://www.asplos-conference.org/asplos2020/
-  deadline: "2019-08-16"
-  abstract_deadline: "2019-08-09"
-  date: "2020-03-16"
+  deadline: '2019-08-16'
+  abstract_deadline: '2019-08-09'
+  date: '2020-03-16'
   place: Lausanne, Switzerland
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
 - name: ASPLOS
   description: Architectural Support for Programming Languages and Operating Systems
   year: 2019
   link: https://www.asplos-conference.org/asplos2019/
-  deadline: "2018-08-07"
-  note: 
-  abstract_deadline: "2018-07-31"
-  date: "2019-04-13"
+  deadline: '2018-08-07'
+  note: null
+  abstract_deadline: '2018-07-31'
+  date: '2019-04-13'
   place: Providence, RI
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: ASPLOS
   description: Architectural Support for Programming Languages and Operating Systems
   year: 2018
   link: https://www.sigarch.org/call-contributions/asplos-2018/
-  deadline: "2017-08-11"
-  note: 
-  abstract_deadline: "2017-08-04"
-  date: "2018-03-24"
+  deadline: '2017-08-11'
+  note: null
+  abstract_deadline: '2017-08-04'
+  date: '2018-03-24'
   place: Williamsburg, VA
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: ASPLOS
   description: Architectural Support for Programming Languages and Operating Systems
   year: 2017
   link: https://www.asplos-conference.org/asplos2017/
-  deadline: "2016-08-15"
-  note: 
-  abstract_deadline: "2016-08-05"
-  date: "2017-04-08"
-  place: "Xi'an, China"
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
-
+  deadline: '2016-08-15'
+  note: null
+  abstract_deadline: '2016-08-05'
+  date: '2017-04-08'
+  place: Xi'an, China
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: ASPLOS
   description: Architectural Support for Programming Languages and Operating Systems
   year: 2016
   link: https://www.asplos-conference.org/asplos2016/
-  deadline: "2015-08-12"
-  note: 
-  abstract_deadline: "2015-08-05"
-  date: "2016-04-02"
+  deadline: '2015-08-12'
+  note: null
+  abstract_deadline: '2015-08-05'
+  date: '2016-04-02'
   place: Atlanta, GA
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: ISCA
   description: International Symposium on Computer Architecture
   year: 2025
   link: https://www.iscaconf.org/isca2025/
-  deadline: "2024-11-22"
-  note: 
-  abstract_deadline: "2024-11-15"
-  date: "2025-06-21"
+  deadline: '2024-11-22'
+  note: null
+  abstract_deadline: '2024-11-15'
+  date: '2025-06-21'
   place: Portland, OR
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jean-Luc Gaudiot, Hironori Kasahara
   program_chair: Daniel Sorin
-
+  series_link: https://www.isca.org/
 - name: ISCA
   description: International Symposium on Computer Architecture
   year: 2024
   link: https://www.iscaconf.org/isca2024/
-  deadline: "2023-11-21"
-  note: 
-  abstract_deadline: "2023-11-14"
-  date: "2024-06-29"
+  deadline: '2023-11-21'
+  note: null
+  abstract_deadline: '2023-11-14'
+  date: '2024-06-29'
   place: Buenos Aires, Argentina
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Augusto Vega, Esteban Mocskos
   program_chair: Sandhya Dwarkadas, Rajeev Balasubramonian
-
+  series_link: https://www.isca.org/
 - name: ISCA
   description: International Symposium on Computer Architecture
   year: 2023
   link: https://www.iscaconf.org/isca2023/
-  deadline: "2022-11-21"
-  note: 
-  abstract_deadline: "2022-11-14"
-  date: "2023-06-17"
+  deadline: '2022-11-21'
+  note: null
+  abstract_deadline: '2022-11-14'
+  date: '2023-06-17'
   place: Orlando, FL
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Yan Solihin, Mark Heinrich
   program_chair: Hyesoon Kim
-
+  series_link: https://www.isca.org/
 - name: ISCA
   description: International Symposium on Computer Architecture
   year: 2022
   link: https://www.iscaconf.org/isca2022/
-  deadline: "2021-11-23"
-  note: 
-  date: "2022-06-18"
+  deadline: '2021-11-23'
+  note: null
+  date: '2022-06-18'
   place: New York, NY
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Valentina Salapura, Mohamed Zahran
   program_chair: Fred Chong
-
+  series_link: https://www.isca.org/
 - name: ISCA
   description: International Symposium on Computer Architecture
   year: 2021
   link: https://www.iscaconf.org/isca2021/
-  deadline: "2020-11-24"
-  note: 
-  date: "2021-05-22"
+  deadline: '2020-11-24'
+  note: null
+  date: '2021-05-22'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: José Martínez, José Duato
   program_chair: Lizy K. John
-
+  series_link: https://www.isca.org/
 - name: ISCA
   description: International Symposium on Computer Architecture
   year: 2020
   link: https://www.iscaconf.org/isca2020/
-  deadline: "2019-11-26"
-  note: 
-  date: "2020-05-29"
+  deadline: '2019-11-26'
+  note: null
+  date: '2020-05-29'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: José Martínez, José Duato
   program_chair: Lieven Eeckhout
-
+  series_link: https://www.isca.org/
 - name: ISCA
   description: International Symposium on Computer Architecture
   year: 2019
   link: https://www.iscaconf.org/isca2019/
-  deadline: "2018-12-07"
-  note: 
-  abstract_deadline: "2018-12-03"
-  date: "2019-06-22"
+  deadline: '2018-12-07'
+  note: null
+  abstract_deadline: '2018-12-03'
+  date: '2019-06-22'
   place: Phoenix, AZ
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Srilatha (Bobbie) Manne
   program_chair: Hillery Hunter
-
+  series_link: https://www.isca.org/
 - name: ISCA
   description: International Symposium on Computer Architecture
   year: 2018
   link: https://www.iscaconf.org/isca2018/
-  deadline: "2017-11-21"
-  note: 
-  abstract_deadline: "2017-11-14"
-  date: "2018-06-02"
+  deadline: '2017-11-21'
+  note: null
+  abstract_deadline: '2017-11-14'
+  date: '2018-06-02'
   place: Los Angeles, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Murali Annavaram, Timothy M. Pinkston
   program_chair: Babak Falsafi
-
+  series_link: https://www.isca.org/
 - name: ISCA
   description: International Symposium on Computer Architecture
   year: 2017
   link: https://www.iscaconf.org/isca2017/
-  deadline: "2016-11-18"
-  note: 
-  abstract_deadline: "2016-11-11"
-  date: "2017-06-24"
+  deadline: '2016-11-18'
+  note: null
+  abstract_deadline: '2016-11-11'
+  date: '2017-06-24'
   place: Toronto, Canada
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Andreas Moshovos
   program_chair: David Brooks
-
+  series_link: https://www.isca.org/
 - name: ISCA
   description: International Symposium on Computer Architecture
   year: 2016
   link: https://www.iscaconf.org/isca2016/
-  deadline: "2015-11-15"
-  note: 
-  abstract_deadline: "2015-11-08"
-  date: "2016-06-18"
+  deadline: '2015-11-15'
+  note: null
+  abstract_deadline: '2015-11-08'
+  date: '2016-06-18'
   place: Seoul, South Korea
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Sang Lyul Min, Gabriel Loh
-  program_chair: Andre Seznec  
-
+  program_chair: Andre Seznec
+  series_link: https://www.isca.org/
 - name: MICRO
   description: IEEE/ACM International Symposium on Microarchitecture
   year: 2025
   link: https://microarch.org/micro58/
-  deadline: "2025-04-11"
-  note: 
-  abstract_deadline: "2025-04-04"
-  date: "2025-10-12"
+  deadline: '2025-04-11'
+  note: null
+  abstract_deadline: '2025-04-04'
+  date: '2025-10-12'
   place: Seoul, South Korea
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Hanjun Kim, Won Woo Ro
   program_chair: Minsoo Rhu, Radu Teodorescu
-
+  series_link: https://micro.org/
 - name: MICRO
   description: IEEE/ACM International Symposium on Microarchitecture
   year: 2024
   link: https://microarch.org/micro57/
-  deadline: "2024-04-18"
-  note: 
-  abstract_deadline: "2024-04-11"
-  date: "2024-11-02"
+  deadline: '2024-04-18'
+  note: null
+  abstract_deadline: '2024-04-11'
+  date: '2024-11-02'
   place: Austin, TX
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Paul V. Gratz, Jason Clemons, Jose Joao
   program_chair: Daniel A. Jiménez, Alaa R. Alameldeen
-
+  series_link: https://micro.org/
 - name: MICRO
   description: IEEE/ACM International Symposium on Microarchitecture
   year: 2023
   link: https://microarch.org/micro56/
-  deadline: "2023-04-28"
-  note: 
-  abstract_deadline: "2023-04-21"
-  date: "2023-10-28"
+  deadline: '2023-04-28'
+  note: null
+  abstract_deadline: '2023-04-21'
+  date: '2023-10-28'
   place: Toronto, Canada
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Gennady Pekhimenko
   program_chair: Samira Khan, Yanos Sazeides
-
+  series_link: https://micro.org/
 - name: MICRO
   description: IEEE/ACM International Symposium on Microarchitecture
   year: 2022
   link: https://microarch.org/micro55/
-  deadline: "2022-04-21"
-  note: 
-  abstract_deadline: "2022-04-14"
-  date: "2022-10-01"
+  deadline: '2022-04-21'
+  note: null
+  abstract_deadline: '2022-04-14'
+  date: '2022-10-01'
   place: Chicago, IL
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Nikos Hardavellas, Simone Campanoni
   program_chair: Boris Grot, Ulya Karpuzcu
-
+  series_link: https://micro.org/
 - name: MICRO
   description: IEEE/ACM International Symposium on Microarchitecture
   year: 2021
   link: https://microarch.org/micro54/
-  deadline: "2021-04-16"
-  note: 
-  abstract_deadline: "2021-04-09"
-  date: "2021-10-18"
+  deadline: '2021-04-16'
+  note: null
+  abstract_deadline: '2021-04-09'
+  date: '2021-10-18'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Dimitris Gizopoulos
   program_chair: Jishen Zhao, Aamer Jaleel
-
+  series_link: https://micro.org/
 - name: MICRO
   description: IEEE/ACM International Symposium on Microarchitecture
   year: 2020
   link: https://microarch.org/micro53/
-  deadline: "2020-04-17"
-  note: 
-  abstract_deadline: "2020-04-10"
-  date: "2020-10-17"
+  deadline: '2020-04-17'
+  note: null
+  abstract_deadline: '2020-04-10'
+  date: '2020-10-17'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Dimitris Gizopoulos
   program_chair: Jun Yang, Mattan Erez
-
+  series_link: https://micro.org/
 - name: MICRO
   description: IEEE/ACM International Symposium on Microarchitecture
   year: 2019
   link: https://microarch.org/micro52/
-  deadline: "2019-04-05"
-  note: 
-  abstract_deadline: "2019-03-29"
-  date: "2019-10-12"
+  deadline: '2019-04-05'
+  note: null
+  abstract_deadline: '2019-03-29'
+  date: '2019-10-12'
   place: Columbus, OH
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Radu Teodorescu, Dhabaleswar K. Panda
   program_chair: Tor Aamodt, Reetuparna Das
-
+  series_link: https://micro.org/
 - name: MICRO
   description: IEEE/ACM International Symposium on Microarchitecture
   year: 2018
   link: https://microarch.org/micro51/
-  deadline: "2018-04-06"
-  note: 
-  abstract_deadline: "2018-03-30"
-  date: "2018-10-20"
+  deadline: '2018-04-06'
+  note: null
+  abstract_deadline: '2018-03-30'
+  date: '2018-10-20'
   place: Fukuoka, Japan
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Mark Oskin, Koji Inoue
   program_chair: Hyesoon Kim, Sudhakar Yalamanchili
-
+  series_link: https://micro.org/
 - name: MICRO
   description: IEEE/ACM International Symposium on Microarchitecture
   year: 2017
   link: https://microarch.org/micro50/
-  deadline: "2017-04-04"
-  note: 
-  abstract_deadline: "2017-03-28"
-  date: "2017-10-14"
+  deadline: '2017-04-04'
+  note: null
+  abstract_deadline: '2017-03-28'
+  date: '2017-10-14'
   place: Boston, MA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: David H. Albonesi, Gabriel Loh
   program_chair: Onur Mutlu, Josep Torrellas
-
+  series_link: https://micro.org/
 - name: MICRO
   description: IEEE/ACM International Symposium on Microarchitecture
   year: 2016
   link: https://microarch.org/micro49/
-  deadline: "2016-04-10"
-  note: 
-  abstract_deadline: "2016-04-03"
-  date: "2016-10-15"
+  deadline: '2016-04-10'
+  note: null
+  abstract_deadline: '2016-04-03'
+  date: '2016-10-15'
   place: Taipei, Taiwan
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Wei-Chung Hsu, Chia-Lin Yang
-  program_chair: Mikko H. Lipasti, Gabriel Loh  
-
+  program_chair: Mikko H. Lipasti, Gabriel Loh
+  series_link: https://micro.org/
 - name: HPCA
   description: IEEE International Symposium on High-Performance Computer Architecture
   year: 2026
   link: https://hpca-conf.org/2026/
-  deadline: "2025-08-01"
-  note: 
-  abstract_deadline: "2025-07-25"
-  date: "2026-01-31"
+  deadline: '2025-08-01'
+  note: null
+  abstract_deadline: '2025-07-25'
+  date: '2026-01-31'
   place: Sydney, NSW, Australia
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Shuaiwen Leon Song
-  program_chair:
-
+  program_chair: null
+  series_link: https://hpca.org/
 - name: HPCA
   description: IEEE International Symposium on High-Performance Computer Architecture
   year: 2025
   link: https://hpca-conf.org/2025/
-  deadline: "2024-08-02"
-  note: 
-  abstract_deadline: "2024-07-26"
-  date: "2025-03-01"
+  deadline: '2024-08-02'
+  note: null
+  abstract_deadline: '2024-07-26'
+  date: '2025-03-01'
   place: Las Vegas, NV
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Hung-Wei Tseng
   program_chair: Anand Sivasubramaniam
-
+  series_link: https://hpca.org/
 - name: HPCA
   description: IEEE International Symposium on High-Performance Computer Architecture
   year: 2024
   link: https://www.hpca-conf.org/2024/program/main.php
-  deadline: "2023-08-04"
-  note: 
-  abstract_deadline: "2023-07-28"
-  date: "2024-03-02"
+  deadline: '2023-08-04'
+  note: null
+  abstract_deadline: '2023-07-28'
+  date: '2024-03-02'
   place: Edinburgh, UK
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Boris Grot
   program_chair: John Kim
-
+  series_link: https://hpca.org/
 - name: HPCA
   description: IEEE International Symposium on High-Performance Computer Architecture
   year: 2023
   link: https://hpca-conf.org/2023/
-  deadline: "2022-08-01"
-  note: 
-  abstract_deadline: "2022-07-25"
-  date: "2023-02-25"
+  deadline: '2022-08-01'
+  note: null
+  abstract_deadline: '2022-07-25'
+  date: '2023-02-25'
   place: Montreal, Canada
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: J. Nelson Amaral
   program_chair: David Kaeli
-
+  series_link: https://hpca.org/
 - name: HPCA
   description: IEEE International Symposium on High-Performance Computer Architecture
   year: 2022
   link: https://hpca-conf.org/2022/
-  deadline: "2021-07-30"
-  note: 
-  abstract_deadline: "2021-07-23"
-  date: "2022-04-02"
+  deadline: '2021-07-30'
+  note: null
+  abstract_deadline: '2021-07-23'
+  date: '2022-04-02'
   place: Seoul, South Korea
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jung Ho Ahn, John Kim
   program_chair: Stefanos Kaxiras
-
+  series_link: https://hpca.org/
 - name: HPCA
   description: IEEE International Symposium on High-Performance Computer Architecture
   year: 2021
   link: https://hpca-conf.org/2021/
-  deadline: "2020-07-31"
-  note: 
-  abstract_deadline: "2020-07-24"
-  date: "2021-02-27"
+  deadline: '2020-07-31'
+  note: null
+  abstract_deadline: '2020-07-24'
+  date: '2021-02-27'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jung Ho Ahn, John Kim
   program_chair: Murali Annavaram
-
+  series_link: https://hpca.org/
 - name: HPCA
   description: IEEE International Symposium on High-Performance Computer Architecture
   year: 2020
   link: https://hpca-conf.org/2020/
-  deadline: "2019-08-06"
-  note: 
-  abstract_deadline: "2019-07-30"
-  date: "2020-02-22"
+  deadline: '2019-08-06'
+  note: null
+  abstract_deadline: '2019-07-30'
+  date: '2020-02-22'
   place: San Diego, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Dean Tullsen, Hadi Esmaeilzadeh
   program_chair: Yan Solihin
-
+  series_link: https://hpca.org/
 - name: HPCA
   description: IEEE International Symposium on High-Performance Computer Architecture
   year: 2019
   link: http://hpca2019.seas.gwu.edu/
-  deadline: "2018-08-03"
-  note: 
-  abstract_deadline: "2018-07-27"
-  date: "2019-02-16"
+  deadline: '2018-08-03'
+  note: null
+  abstract_deadline: '2018-07-27'
+  date: '2019-02-16'
   place: Washington, DC
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Ahmed Louri, Guru Prasadh Venkataramani
   program_chair: Rajeev Balasubramonian, Vijayalakshmi Srinivasan
-
+  series_link: https://hpca.org/
 - name: HPCA
   description: IEEE International Symposium on High-Performance Computer Architecture
   year: 2018
   link: https://hpca2018.ece.ucsb.edu/
-  deadline: "2017-07-30"
-  note: 
-  abstract_deadline: "2017-07-23"
-  date: "2018-02-24"
+  deadline: '2017-07-30'
+  note: null
+  abstract_deadline: '2017-07-23'
+  date: '2018-02-24'
   place: Vienna, Austria
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Michael Gschwind
   program_chair: Yuan Xie
-
+  series_link: https://hpca.org/
 - name: HPCA
   description: IEEE International Symposium on High-Performance Computer Architecture
   year: 2017
   link: https://hpca2017.org/
-  deadline: "2016-08-01"
-  note: 
-  abstract_deadline: "2016-07-25"
-  date: "2017-02-04"
+  deadline: '2016-08-01'
+  note: null
+  abstract_deadline: '2016-07-25'
+  date: '2017-02-04'
   place: Austin, TX
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Derek Chiou
   program_chair: Daniel A. Jiménez
-
+  series_link: https://hpca.org/
 - name: HPCA
   description: IEEE International Symposium on High-Performance Computer Architecture
   year: 2016
   link: https://hpca22.site.ac.upc.edu/
-  deadline: "2015-07-30"
-  note: 
-  abstract_deadline: "2015-07-23"
-  date: "2016-03-12"
+  deadline: '2015-07-30'
+  note: null
+  abstract_deadline: '2015-07-23'
+  date: '2016-03-12'
   place: Barcelona, Spain
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Ramon Canal, Antonio Gonzalez
   program_chair: José F. Martínez
-
-## Computer Networks
+  series_link: https://hpca.org/
 - name: SIGCOMM
   description: ACM Special Interest Group on Data Communication Conference
   year: 2025
   link: https://conferences.sigcomm.org/sigcomm/2025/
-  deadline: "2025-01-31"
-  note: 
-  abstract_deadline: "2025-01-24"
-  date: "2025-09-08"
+  deadline: '2025-01-31'
+  note: null
+  abstract_deadline: '2025-01-24'
+  date: '2025-09-08'
   place: Coimbra, Portugal
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://www.sigcomm.org/
 - name: SIGCOMM
   description: ACM Special Interest Group on Data Communication Conference
   year: 2024
   link: https://conferences.sigcomm.org/sigcomm/2024/
-  deadline: "2024-02-02"
-  note: 
-  abstract_deadline: "2024-01-26"
-  date: "2024-08-04"
+  deadline: '2024-02-02'
+  note: null
+  abstract_deadline: '2024-01-26'
+  date: '2024-08-04'
   place: Sydney, Australia
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://www.sigcomm.org/
 - name: SIGCOMM
   description: ACM Special Interest Group on Data Communication Conference
   year: 2023
   link: https://conferences.sigcomm.org/sigcomm/2023/
-  deadline: "2023-02-15"
-  note: 
-  abstract_deadline: "2023-02-08"
-  date: "2023-09-10"
+  deadline: '2023-02-15'
+  note: null
+  abstract_deadline: '2023-02-08'
+  date: '2023-09-10'
   place: New York, NY
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://www.sigcomm.org/
 - name: SIGCOMM
   description: ACM Special Interest Group on Data Communication Conference
   year: 2022
   link: https://conferences.sigcomm.org/sigcomm/2022/
-  deadline: "2022-02-02"
-  note: 
-  abstract_deadline: "2022-01-26"
-  date: "2022-08-22"
+  deadline: '2022-02-02'
+  note: null
+  abstract_deadline: '2022-01-26'
+  date: '2022-08-22'
   place: Amsterdam, Netherlands
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://www.sigcomm.org/
 - name: SIGCOMM
   description: ACM Special Interest Group on Data Communication Conference
   year: 2021
   link: https://conferences.sigcomm.org/sigcomm/2021/
-  deadline: "2021-01-27"
-  note: 
-  abstract_deadline: "2021-01-20"
-  date: "2021-08-23"
+  deadline: '2021-01-27'
+  note: null
+  abstract_deadline: '2021-01-20'
+  date: '2021-08-23'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://www.sigcomm.org/
 - name: SIGCOMM
   description: ACM Special Interest Group on Data Communication Conference
   year: 2020
   link: https://conferences.sigcomm.org/sigcomm/2020/
-  deadline: "2020-02-07"
-  note: 
-  date: "2020-08-10"
+  deadline: '2020-02-07'
+  note: null
+  date: '2020-08-10'
   place: New York, NY
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://www.sigcomm.org/
 - name: SIGCOMM
   description: ACM Special Interest Group on Data Communication Conference
   year: 2019
   link: https://conferences.sigcomm.org/sigcomm/2019/
-  deadline: "2019-01-31"
-  note: 
-  abstract_deadline: "2019-01-24"
-  date: "2019-08-19"
+  deadline: '2019-01-31'
+  note: null
+  abstract_deadline: '2019-01-24'
+  date: '2019-08-19'
   place: Beijing, China
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://www.sigcomm.org/
 - name: SIGCOMM
   description: ACM Special Interest Group on Data Communication Conference
   year: 2018
   link: https://conferences.sigcomm.org/sigcomm/2018/
-  deadline: "2018-01-31"
-  note: 
-  abstract_deadline: "2018-01-24"
-  date: "2018-08-20"
+  deadline: '2018-01-31'
+  note: null
+  abstract_deadline: '2018-01-24'
+  date: '2018-08-20'
   place: Budapest, Hungary
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://www.sigcomm.org/
 - name: SIGCOMM
   description: ACM Special Interest Group on Data Communication Conference
   year: 2017
   link: https://conferences.sigcomm.org/sigcomm/2017/
-  deadline: "2017-01-20"
-  note: 
-  abstract_deadline: "2017-01-27"
-  date: "2017-08-21"
+  deadline: '2017-01-20'
+  note: null
+  abstract_deadline: '2017-01-27'
+  date: '2017-08-21'
   place: Los Angeles, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://www.sigcomm.org/
 - name: SIGCOMM
   description: ACM Special Interest Group on Data Communication Conference
   year: 2016
   link: https://conferences.sigcomm.org/sigcomm/2016/
-  deadline: "2016-01-29"
-  note: 
-  abstract_deadline: "2016-01-22"
-  date: "2016-08-22"
+  deadline: '2016-01-29'
+  note: null
+  abstract_deadline: '2016-01-22'
+  date: '2016-08-22'
   place: Florianópolis, Brazil
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://www.sigcomm.org/
 - name: NSDI
   description: USENIX Symposium on Networked Systems Design and Implementation
   year: 2025
   link: https://www.usenix.org/conference/nsdi25
-  deadline: "2024-05-07"
-  note: 
-  abstract_deadline: "2024-04-30"
-  date: "2025-04-28"
+  deadline: '2024-05-07'
+  note: null
+  abstract_deadline: '2024-04-30'
+  date: '2025-04-28'
   place: Philadelphia, PA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: NSDI
   description: USENIX Symposium on Networked Systems Design and Implementation
   year: 2024
   link: https://www.usenix.org/conference/nsdi24
-  deadline: "2023-05-04"
-  note: 
-  abstract_deadline: "2023-04-27"
-  date: "2024-04-16"
+  deadline: '2023-05-04'
+  note: null
+  abstract_deadline: '2023-04-27'
+  date: '2024-04-16'
   place: Santa Clara, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: NSDI
   description: USENIX Symposium on Networked Systems Design and Implementation
   year: 2023
   link: https://www.usenix.org/conference/nsdi23
-  deadline: "2022-09-20"
-  note: "Cycle 2/2"
-  abstract_deadline: "2022-09-13"
-  date: "2023-04-17"
+  deadline: '2022-09-20'
+  note: Cycle 2/2
+  abstract_deadline: '2022-09-13'
+  date: '2023-04-17'
   place: Boston, MA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: NSDI
   description: USENIX Symposium on Networked Systems Design and Implementation
   year: 2023
   link: https://www.usenix.org/conference/nsdi23
-  deadline: "2022-04-20"
-  note: "Cycle 1/2"
-  abstract_deadline: "2022-04-13"
-  date: "2023-04-17"
+  deadline: '2022-04-20'
+  note: Cycle 1/2
+  abstract_deadline: '2022-04-13'
+  date: '2023-04-17'
   place: Boston, MA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: NSDI
   description: USENIX Symposium on Networked Systems Design and Implementation
   year: 2022
   link: https://www.usenix.org/conference/nsdi22
-  deadline: "2021-09-15"
-  note: "Cycle 2/2"
-  abstract_deadline: "2021-09-09"
-  date: "2022-04-04"
+  deadline: '2021-09-15'
+  note: Cycle 2/2
+  abstract_deadline: '2021-09-09'
+  date: '2022-04-04'
   place: Renton, WA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: NSDI
   description: USENIX Symposium on Networked Systems Design and Implementation
   year: 2022
   link: https://www.usenix.org/conference/nsdi22
-  deadline: "2021-03-10"
-  note: "Cycle 1/2"
-  abstract_deadline: "2021-03-04"
-  date: "2022-04-04"
+  deadline: '2021-03-10'
+  note: Cycle 1/2
+  abstract_deadline: '2021-03-04'
+  date: '2022-04-04'
   place: Renton, WA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: NSDI
   description: USENIX Symposium on Networked Systems Design and Implementation
   year: 2021
   link: https://www.usenix.org/conference/nsdi21
-  deadline: "2020-09-17"
-  note: "Cycle 2/2"
-  abstract_deadline: "2020-09-10"
-  date: "2021-04-12"
+  deadline: '2020-09-17'
+  note: Cycle 2/2
+  abstract_deadline: '2020-09-10'
+  date: '2021-04-12'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: NSDI
   description: USENIX Symposium on Networked Systems Design and Implementation
   year: 2021
   link: https://www.usenix.org/conference/nsdi21
-  deadline: "2020-04-17"
-  note: "Cycle 1/2"
-  abstract_deadline: "2020-04-10"
-  date: "2021-04-12"
+  deadline: '2020-04-17'
+  note: Cycle 1/2
+  abstract_deadline: '2020-04-10'
+  date: '2021-04-12'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: NSDI
   description: USENIX Symposium on Networked Systems Design and Implementation
   year: 2020
   link: https://www.usenix.org/conference/nsdi20
-  deadline: "2019-09-19"
-  note: "Cycle 2/2"
-  abstract_deadline: "2019-09-12"
-  date: "2020-02-25"
+  deadline: '2019-09-19'
+  note: Cycle 2/2
+  abstract_deadline: '2019-09-12'
+  date: '2020-02-25'
   place: Santa Clara, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: NSDI
   description: USENIX Symposium on Networked Systems Design and Implementation
   year: 2020
   link: https://www.usenix.org/conference/nsdi20
-  deadline: "2019-03-19"
-  note: "Cycle 1/2"
-  abstract_deadline: "2019-03-12"
-  date: "2020-02-25"
+  deadline: '2019-03-19'
+  note: Cycle 1/2
+  abstract_deadline: '2019-03-12'
+  date: '2020-02-25'
   place: Santa Clara, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: NSDI
   description: USENIX Symposium on Networked Systems Design and Implementation
   year: 2019
   link: https://www.usenix.org/conference/nsdi19
-  deadline: "2018-09-20"
-  note: "Cycle 2/2"
-  abstract_deadline: "2018-09-13"
-  date: "2019-02-26"
+  deadline: '2018-09-20'
+  note: Cycle 2/2
+  abstract_deadline: '2018-09-13'
+  date: '2019-02-26'
   place: Boston, MA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: NSDI
   description: USENIX Symposium on Networked Systems Design and Implementation
   year: 2019
   link: https://www.usenix.org/conference/nsdi19
-  deadline: "2018-05-31"
-  note: "Cycle 1/2"
-  abstract_deadline: "2018-05-24"
-  date: "2019-02-26"
+  deadline: '2018-05-31'
+  note: Cycle 1/2
+  abstract_deadline: '2018-05-24'
+  date: '2019-02-26'
   place: Boston, MA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: NSDI
   description: USENIX Symposium on Networked Systems Design and Implementation
   year: 2018
   link: https://www.usenix.org/conference/nsdi18
-  deadline: "2017-09-25"
-  note: 
-  abstract_deadline: "2017-09-18"
-  date: "2018-04-09"
+  deadline: '2017-09-25'
+  note: null
+  abstract_deadline: '2017-09-18'
+  date: '2018-04-09'
   place: Renton, WA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: NSDI
   description: USENIX Symposium on Networked Systems Design and Implementation
   year: 2017
   link: https://www.usenix.org/conference/nsdi17
-  deadline: "2016-09-21"
-  note: 
-  abstract_deadline: "2016-09-14"
-  date: "2017-03-27"
+  deadline: '2016-09-21'
+  note: null
+  abstract_deadline: '2016-09-14'
+  date: '2017-03-27'
   place: Boston, MA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: NSDI
   description: USENIX Symposium on Networked Systems Design and Implementation
   year: 2016
   link: https://www.usenix.org/conference/nsdi16/call-for-papers
-  deadline: "2015-09-24"
-  note: 
-  abstract_deadline: "2015-09-17"
-  date: "2016-03-16"
+  deadline: '2015-09-24'
+  note: null
+  abstract_deadline: '2015-09-17'
+  date: '2016-03-16'
   place: Santa Clara, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
-## Computer Security
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: CCS
   description: ACM Conference on Computer and Communications Security
   year: 2025
   link: https://www.sigsac.org/ccs/CCS2025/
-  abstract_deadline: "2025-04-07"
-  deadline: "2025-04-14"
-  notification_date: "2025-07-01"
+  abstract_deadline: '2025-04-07'
+  deadline: '2025-04-14'
+  notification_date: '2025-07-01'
   note: Cycle 2/2
-  date: "2025-10-13"
+  date: '2025-10-13'
   place: Taipei, Taiwan
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://ccs.org/
 - name: CCS
   description: ACM Conference on Computer and Communications Security
   year: 2025
   link: https://www.sigsac.org/ccs/CCS2025/
-  deadline: "2025-01-09"
-  notification_date: "2025-03-28"
+  deadline: '2025-01-09'
+  notification_date: '2025-03-28'
   note: Cycle 1/2
-  abstract_deadline: "2025-01-02"
-  date: "2025-10-13"
+  abstract_deadline: '2025-01-02'
+  date: '2025-10-13'
   place: Taipei, Taiwan
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://ccs.org/
 - name: CCS
   description: ACM Conference on Computer and Communications Security
   year: 2024
   link: https://www.sigsac.org/ccs/CCS2024/
-  deadline: "2024-04-29"
+  deadline: '2024-04-29'
   note: Cycle 2/2
-  notification_date: "2024-07-04"
-  date: "2024-11-14"
+  notification_date: '2024-07-04'
+  date: '2024-11-14'
   place: Salt Lake City, UT
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://ccs.org/
 - name: CCS
   description: ACM Conference on Computer and Communications Security
   year: 2024
   link: https://www.sigsac.org/ccs/CCS2024/
-  deadline: "2024-01-28"
+  deadline: '2024-01-28'
   note: Cycle 1/2
-  notification_date: "2024-04-03"
-  date: "2024-11-14"
+  notification_date: '2024-04-03'
+  date: '2024-11-14'
   place: Salt Lake City, UT
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://ccs.org/
 - name: CCS
   description: ACM Conference on Computer and Communications Security
   year: 2023
   link: https://www.sigsac.org/ccs/CCS2023/
-  deadline: "2023-05-04"
+  deadline: '2023-05-04'
   note: Cycle 2/2
-  notification_date: "2023-09-02"
-  date: "2023-11-26"
+  notification_date: '2023-09-02'
+  date: '2023-11-26'
   place: Copenhagen, Denmark
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://ccs.org/
 - name: CCS
   description: ACM Conference on Computer and Communications Security
   year: 2023
   link: https://www.sigsac.org/ccs/CCS2023/
-  deadline: "2023-01-19"
+  deadline: '2023-01-19'
   note: Cycle 1/2
-  notification_date: "2023-03-17"
-  date: "2023-11-26"
+  notification_date: '2023-03-17'
+  date: '2023-11-26'
   place: Copenhagen, Denmark
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://ccs.org/
 - name: CCS
   description: ACM Conference on Computer and Communications Security
   year: 2022
   link: https://www.sigsac.org/ccs/CCS2022/
-  deadline: "2022-05-02"
-  note: Cycle 2/2 
-  notification_date: "2022-07-15"
-  date: "2022-11-07"
+  deadline: '2022-05-02'
+  note: Cycle 2/2
+  notification_date: '2022-07-15'
+  date: '2022-11-07'
   place: Los Angeles, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://ccs.org/
 - name: CCS
   description: ACM Conference on Computer and Communications Security
   year: 2022
   link: https://www.sigsac.org/ccs/CCS2022/
-  deadline: "2022-01-14"
+  deadline: '2022-01-14'
   note: Cycle 1/2
-  notification_date: "2022-03-10"
-  date: "2022-11-07"
+  notification_date: '2022-03-10'
+  date: '2022-11-07'
   place: Los Angeles, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://ccs.org/
 - name: CCS
   description: ACM Conference on Computer and Communications Security
   year: 2021
   link: https://www.sigsac.org/ccs/CCS2021/
-  deadline: "2021-03-06"
+  deadline: '2021-03-06'
   note: Cycle 2/2
-  notification_date: "2021-07-20"
-  date: "2021-11-15"
+  notification_date: '2021-07-20'
+  date: '2021-11-15'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://ccs.org/
 - name: CCS
   description: ACM Conference on Computer and Communications Security
   year: 2021
   link: https://www.sigsac.org/ccs/CCS2021/
-  deadline: "2021-01-20"
+  deadline: '2021-01-20'
   note: Cycle 1/2
-  notification_date: "2021-03-22"
-  date: "2021-11-15"
+  notification_date: '2021-03-22'
+  date: '2021-11-15'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://ccs.org/
 - name: CCS
   description: ACM Conference on Computer and Communications Security
   year: 2020
   link: https://www.sigsac.org/ccs/CCS2020/
-  deadline: "2020-05-04"
+  deadline: '2020-05-04'
   note: Cycle 2/2
-  notification_date: "2020-07-28"
-  date: "2020-11-09"
+  notification_date: '2020-07-28'
+  date: '2020-11-09'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://ccs.org/
 - name: CCS
   description: ACM Conference on Computer and Communications Security
   year: 2020
   link: https://www.sigsac.org/ccs/CCS2020/
-  deadline: "2020-01-20"
+  deadline: '2020-01-20'
   note: Cycle 1/2
-  notification_date: "2020-03-30"
-  date: "2020-11-09"
+  notification_date: '2020-03-30'
+  date: '2020-11-09'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://ccs.org/
 - name: CCS
   description: ACM Conference on Computer and Communications Security
   year: 2019
   link: https://www.sigsac.org/ccs/CCS2019/
-  deadline: "2019-05-15"
+  deadline: '2019-05-15'
   note: Cycle 2/2
-  notification_date: "2019-06-30"
-  date: "2019-11-11"
+  notification_date: '2019-06-30'
+  date: '2019-11-11'
   place: London, UK
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://ccs.org/
 - name: CCS
   description: ACM Conference on Computer and Communications Security
   year: 2019
   link: https://www.sigsac.org/ccs/CCS2019/
-  deadline: "2019-02-05"
+  deadline: '2019-02-05'
   note: Cycle 1/2
-  notification_date: "2019-06-30"
-  date: "2019-11-11"
+  notification_date: '2019-06-30'
+  date: '2019-11-11'
   place: London, UK
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://ccs.org/
 - name: CCS
   description: ACM Conference on Computer and Communications Security
   year: 2018
   link: https://www.sigsac.org/ccs/CCS2018/index.html
-  deadline: "2018-05-09"
-  note: 
-  notification_date: "2018-07-23"
-  date: "2018-10-15"
+  deadline: '2018-05-09'
+  note: null
+  notification_date: '2018-07-23'
+  date: '2018-10-15'
   place: Toronto, Canada
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://ccs.org/
 - name: CCS
   description: ACM Conference on Computer and Communications Security
   year: 2017
   link: https://www.sigsac.org/ccs/CCS2017/
-  deadline: "2017-05-19"
-  note: 
-  notification_date: "2017-08-02"
-  date: "2017-10-30"
+  deadline: '2017-05-19'
+  note: null
+  notification_date: '2017-08-02'
+  date: '2017-10-30'
   place: Dallas, TX
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://ccs.org/
 - name: CCS
   description: ACM Conference on Computer and Communications Security
   year: 2016
   link: https://www.sigsac.org/ccs/CCS2016/index.html
-  deadline: "2016-05-23"
-  note: 
-  notification_date: "2016-07-08"
-  date: "2016-10-24"
+  deadline: '2016-05-23'
+  note: null
+  notification_date: '2016-07-08'
+  date: '2016-10-24'
   place: Vienna, Austria
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://ccs.org/
 - name: IEEE S&P
   description: IEEE Symposium on Security and Privacy
   year: 2025
   link: https://www.ieee-security.org/TC/SP2025/
-  deadline: "2024-11-14"
+  deadline: '2024-11-14'
   note: Cycle 2/2
-  abstract_deadline: "2025-03-10"
-  date: "2025-05-12"
+  abstract_deadline: '2025-03-10'
+  date: '2025-05-12'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: IEEE S&P
   description: IEEE Symposium on Security and Privacy
   year: 2025
   link: https://www.ieee-security.org/TC/SP2025/
-  deadline: "2024-06-06"
+  deadline: '2024-06-06'
   note: Cycle 1/2
-  notification_date: "2024-09-09"
-  date: "2025-05-12"
+  notification_date: '2024-09-09'
+  date: '2025-05-12'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: IEEE S&P
   description: IEEE Symposium on Security and Privacy
   year: 2024
   link: https://www.ieee-security.org/TC/SP2024/
-  deadline: "2023-04-13"
+  deadline: '2023-04-13'
   note: Cycle 3/3
-  notification_date: "2023-07-10"
-  date: "2024-05-20"
+  notification_date: '2023-07-10'
+  date: '2024-05-20'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: IEEE S&P
   description: IEEE Symposium on Security and Privacy
   year: 2024
   link: https://www.ieee-security.org/TC/SP2024/
-  deadline: "2023-08-03"
+  deadline: '2023-08-03'
   note: Cycle 2/3
-  notification_date: "2023-10-27"
-  date: "2024-05-20"
+  notification_date: '2023-10-27'
+  date: '2024-05-20'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: IEEE S&P
   description: IEEE Symposium on Security and Privacy
   year: 2024
   link: https://www.ieee-security.org/TC/SP2024/
-  deadline: "2023-12-06"
+  deadline: '2023-12-06'
   note: Cycle 1/3
-  notification_date: "2024-03-04"
-  date: "2024-05-20"
+  notification_date: '2024-03-04'
+  date: '2024-05-20'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: IEEE S&P
   description: IEEE Symposium on Security and Privacy
   year: 2023
   link: https://www.ieee-security.org/TC/SP2023/
-  deadline: "2022-12-02"
+  deadline: '2022-12-02'
   note: Cycle 3/3
-  notification_date: "2023-03-10"
-  date: "2023-05-22"
+  notification_date: '2023-03-10'
+  date: '2023-05-22'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: IEEE S&P
   description: IEEE Symposium on Security and Privacy
   year: 2023
   link: https://www.ieee-security.org/TC/SP2023/
-  deadline: "2022-08-19"
+  deadline: '2022-08-19'
   note: Cycle 2/3
-  notification_date: "2022-11-09"
-  date: "2023-05-22"
+  notification_date: '2022-11-09'
+  date: '2023-05-22'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: IEEE S&P
   description: IEEE Symposium on Security and Privacy
   year: 2023
   link: https://www.ieee-security.org/TC/SP2023/
-  deadline: "2022-04-01"
+  deadline: '2022-04-01'
   note: Cycle 1/3
-  notification_date: "2022-06-24"
-  date: "2023-05-22"
+  notification_date: '2022-06-24'
+  date: '2023-05-22'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: IEEE S&P
   description: IEEE Symposium on Security and Privacy
   year: 2022
   link: https://www.ieee-security.org/TC/SP2022/
-  deadline: "2021-12-02"
+  deadline: '2021-12-02'
   note: Cycle 3/3
-  notification_date: "2022-03-04"
-  date: "2022-05-23"
+  notification_date: '2022-03-04'
+  date: '2022-05-23'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: IEEE S&P
   description: IEEE Symposium on Security and Privacy
   year: 2022
   link: https://www.ieee-security.org/TC/SP2022/
-  deadline: "2021-08-19"
+  deadline: '2021-08-19'
   note: Cyscle 2/3
-  notification_date: "2021-11-05"
-  date: "2022-05-23"
+  notification_date: '2021-11-05'
+  date: '2022-05-23'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: IEEE S&P
   description: IEEE Symposium on Security and Privacy
   year: 2022
   link: https://www.ieee-security.org/TC/SP2022/
-  deadline: "2021-04-15"
+  deadline: '2021-04-15'
   note: Cycle 1/3
-  notification_date: "2021-07-02"
-  date: "2022-05-23"
+  notification_date: '2021-07-02'
+  date: '2022-05-23'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: IEEE S&P
   description: IEEE Symposium on Security and Privacy
   year: 2021
   link: https://www.ieee-security.org/TC/SP2021/
-  deadline: "2020-12-03"
+  deadline: '2020-12-03'
   note: Cycle 4/4
-  notification_date: "2021-02-19"
-  date: "2021-05-24"
+  notification_date: '2021-02-19'
+  date: '2021-05-24'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: IEEE S&P
   description: IEEE Symposium on Security and Privacy
   year: 2021
   link: https://www.ieee-security.org/TC/SP2021/
-  deadline: "2020-09-03"
+  deadline: '2020-09-03'
   note: Cycle 3/4
-  notification_date: "2020-11-20"
-  date: "2021-05-24"
+  notification_date: '2020-11-20'
+  date: '2021-05-24'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: IEEE S&P
   description: IEEE Symposium on Security and Privacy
   year: 2021
   link: https://www.ieee-security.org/TC/SP2021/
-  deadline: "2020-07-04"
+  deadline: '2020-07-04'
   note: Cycle 2/4
-  notification_date: "2020-08-21"
-  date: "2021-05-24"
+  notification_date: '2020-08-21'
+  date: '2021-05-24'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: IEEE S&P
   description: IEEE Symposium on Security and Privacy
   year: 2021
   link: https://www.ieee-security.org/TC/SP2021/
-  deadline: "2020-03-05"
+  deadline: '2020-03-05'
   note: Cycle 1/4
-  notification_date: "2020-05-22"
-  date: "2021-05-24"
+  notification_date: '2020-05-22'
+  date: '2021-05-24'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: IEEE S&P
   description: IEEE Symposium on Security and Privacy
   year: 2020
   link: https://www.ieee-security.org/TC/SP2020/
-  deadline: "2019-09-15"
+  deadline: '2019-09-15'
   note: Rolling Deadlines (12 cycles with deadlines on the 1st of each month)
-  abstract_deadline: "2019-09-08"
-  date: "2020-05-18"
+  abstract_deadline: '2019-09-08'
+  date: '2020-05-18'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Gabriela Ciocarlie
   program_chair: Hovav Shacham, Alina Oprea
-
 - name: IEEE S&P
   description: IEEE Symposium on Security and Privacy
   year: 2019
   link: https://www.ieee-security.org/TC/SP2019/
-  deadline: "2018-09-15"
+  deadline: '2018-09-15'
   note: Rolling Deadlines (12 cycles with deadlines on the 1st of each month)
-  abstract_deadline: "2018-09-08"
-  date: "2019-05-20"
+  abstract_deadline: '2018-09-08'
+  date: '2019-05-20'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Christopher Kruegel
   program_chair: Hovav Shacham
-
 - name: IEEE S&P
   description: IEEE Symposium on Security and Privacy
   year: 2018
   link: https://www.ieee-security.org/TC/SP2018/
-  deadline: "2017-09-15"
+  deadline: '2017-09-15'
   note: Rolling Deadlines (12 cycles with deadlines on the 1st of each month)
-  abstract_deadline: "2017-09-08"
-  date: "2018-05-21"
+  abstract_deadline: '2017-09-08'
+  date: '2018-05-21'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: Bryan Parno 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Bryan Parno
   program_chair: Christopher Kruegel
-
 - name: IEEE S&P
   description: IEEE Symposium on Security and Privacy
   year: 2017
   link: https://www.ieee-security.org/TC/SP2017/
-  deadline: "2016-11-11"
-  note: 
-  abstract_deadline: "2016-11-04"
-  notification_date: "2017-02-09"
-  date: "2017-05-22"
+  deadline: '2016-11-11'
+  note: null
+  abstract_deadline: '2016-11-04'
+  notification_date: '2017-02-09'
+  date: '2017-05-22'
   place: San Jose, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Úlfar Erlingsson
   program_chair: Bryan Parno
-
 - name: IEEE S&P
   description: IEEE Symposium on Security and Privacy
   year: 2016
   link: https://www.ieee-security.org/TC/SP2016/
-  deadline: "2015-11-13"
-  note: 
-  notification_date: "2016-02-07"
-  date: "2016-05-23"
+  deadline: '2015-11-13'
+  note: null
+  notification_date: '2016-02-07'
+  date: '2016-05-23'
   place: San Jose, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Michael Locasto
   program_chair: Vitaly Shmatikov
-
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2026
   link: https://www.usenix.org/conference/usenixsecurity26
-  deadline: "2026-02-05"
-  abstract_deadline: "2026-01-29"
-  rebuttal_date: "2026-04-16"
-  notification_date: "2026-05-14"
+  deadline: '2026-02-05'
+  abstract_deadline: '2026-01-29'
+  rebuttal_date: '2026-04-16'
+  notification_date: '2026-05-14'
   note: Cycle 2
-  date: "2026-08-12"
+  date: '2026-08-12'
   place: Baltimore, MD
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2025
   link: https://www.usenix.org/conference/usenixsecurity25
-  deadline: "2025-01-22"
+  deadline: '2025-01-22'
   note: Cycle 2/2
-  notification_date: "2025-04-30"
-  date: "2025-08-13"
+  notification_date: '2025-04-30'
+  date: '2025-08-13'
   place: Seattle, WA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2025
   link: https://www.usenix.org/conference/usenixsecurity25
-  deadline: "2024-09-04"
+  deadline: '2024-09-04'
   note: Cycle 1/2
-  notification_date: "2024-12-11"
-  date: "2025-08-13"
+  notification_date: '2024-12-11'
+  date: '2025-08-13'
   place: Seattle, WA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2024
   link: https://www.usenix.org/conference/usenixsecurity24
-  deadline: "2024-02-08"
+  deadline: '2024-02-08'
   note: Cycle 3/3
-  notification_date: "2024-05-08"
-  date: "2024-08-14"
+  notification_date: '2024-05-08'
+  date: '2024-08-14'
   place: Philadelphia, PA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Davide Balzarotti, Wenyuan Xu
-
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2024
   link: https://www.usenix.org/conference/usenixsecurity24
-  deadline: "2023-10-17"
+  deadline: '2023-10-17'
   note: Cycle 2/3
-  notification_date: "2024-02-01"
-  date: "2024-08-14"
+  notification_date: '2024-02-01'
+  date: '2024-08-14'
   place: Philadelphia, PA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Davide Balzarotti, Wenyuan Xu
-
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2024
   link: https://www.usenix.org/conference/usenixsecurity24
-  deadline: "2023-06-06"
+  deadline: '2023-06-06'
   note: Cycle 1/3
-  notification_date: "2023-09-01"
-  date: "2024-08-14"
+  notification_date: '2023-09-01'
+  date: '2024-08-14'
   place: Philadelphia, PA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Davide Balzarotti, Wenyuan Xu
-
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2023
   link: https://www.usenix.org/conference/usenixsecurity23
-  deadline: "2023-02-07"
+  deadline: '2023-02-07'
   note: Cycle 3/3
-  notification_date: "2023-03-08"
-  date: "2023-08-09"
+  notification_date: '2023-03-08'
+  date: '2023-08-09'
   place: Anaheim, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Joe Calandrino, Carmela Troncoso
-
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2023
   link: https://www.usenix.org/conference/usenixsecurity23
-  deadline: "2022-10-11"
+  deadline: '2022-10-11'
   note: Cycle 2/3
-  notification_date: "2022-09-02"
-  date: "2023-08-09"
+  notification_date: '2022-09-02'
+  date: '2023-08-09'
   place: Anaheim, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Joe Calandrino, Carmela Troncoso
-
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2023
   link: https://www.usenix.org/conference/usenixsecurity23
-  deadline: "2022-06-07"
+  deadline: '2022-06-07'
   note: Cycle 1/3
-  notification_date: "2022-09-02"
-  date: "2023-08-09"
+  notification_date: '2022-09-02'
+  date: '2023-08-09'
   place: Anaheim, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Joe Calandrino, Carmela Troncoso
-
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2022
   link: https://www.usenix.org/conference/usenixsecurity22
-  deadline: "2022-02-01"
+  deadline: '2022-02-01'
   note: Cycle 3/3
-  notification_date: "2022-05-02"
-  date: "2022-08-10"
+  notification_date: '2022-05-02'
+  date: '2022-08-10'
   place: Boston, MA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Kevin Butler, Kurt Thomas
-
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2022
   link: https://www.usenix.org/conference/usenixsecurity22
-  deadline: "2021-10-12"
+  deadline: '2021-10-12'
   note: Cycle 2/3
-  notification_date: "2022-01-20"
-  date: "2022-08-10"
+  notification_date: '2022-01-20'
+  date: '2022-08-10'
   place: Boston, MA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Kevin Butler, Kurt Thomas
-
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2022
   link: https://www.usenix.org/conference/usenixsecurity22
-  deadline: "2021-06-08"
+  deadline: '2021-06-08'
   note: Cycle 1/3
-  notification_date: "2021-09-03"
-  date: "2022-08-10"
+  notification_date: '2021-09-03'
+  date: '2022-08-10'
   place: Boston, MA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Kevin Butler, Kurt Thomas
-
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2021
   link: https://www.usenix.org/conference/usenixsecurity21
-  deadline: "2021-02-04"
+  deadline: '2021-02-04'
   note: Cycle 3/3
-  notification_date: "2021-04-30"
-  date: "2021-08-11"
+  notification_date: '2021-04-30'
+  date: '2021-08-11'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Michael Bailey, Rachel Greenstadt
-
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2021
   link: https://www.usenix.org/conference/usenixsecurity21
-  deadline: "2020-10-15"
+  deadline: '2020-10-15'
   note: Cycle 2/3
-  notification_date: "2021-01-21"
-  date: "2021-08-11"
+  notification_date: '2021-01-21'
+  date: '2021-08-11'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Michael Bailey, Rachel Greenstadt
-
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2021
   link: https://www.usenix.org/conference/usenixsecurity21
-  deadline: "2020-06-18"
+  deadline: '2020-06-18'
   note: Cycle 1/3
-  notification_date: "2020-09-11"
-  date: "2021-08-11"
+  notification_date: '2020-09-11'
+  date: '2021-08-11'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Michael Bailey, Rachel Greenstadt
-
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2020
   link: https://www.usenix.org/conference/usenixsecurity20
-  deadline: "2020-02-15"
-  note: 
-  abstract_deadline: "2020-02-08"
-  date: "2020-08-12"
+  deadline: '2020-02-15'
+  note: null
+  abstract_deadline: '2020-02-08'
+  date: '2020-08-12'
   place: Boston, MA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2020
   link: https://www.usenix.org/conference/usenixsecurity20
-  deadline: "2020-02-15"
+  deadline: '2020-02-15'
   note: Cycle 4/4
-  notification_date: "2020-05-15"
-  date: "2020-08-12"
+  notification_date: '2020-05-15'
+  date: '2020-08-12'
   place: Boston, MA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Srdjan Capkun, Franziska Roesner
-
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2020
   link: https://www.usenix.org/conference/usenixsecurity20
-  deadline: "2019-11-15"
+  deadline: '2019-11-15'
   note: Cycle 3/4
-  notification_date: "2019-11-01"
-  date: "2020-08-12"
+  notification_date: '2019-11-01'
+  date: '2020-08-12'
   place: Boston, MA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Srdjan Capkun, Franziska Roesner
-
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2020
   link: https://www.usenix.org/conference/usenixsecurity20
-  deadline: "2019-08-23"
+  deadline: '2019-08-23'
   note: Cycle 2/4
-  notification_date: "2019-11-01"
-  date: "2020-08-12"
+  notification_date: '2019-11-01'
+  date: '2020-08-12'
   place: Boston, MA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Srdjan Capkun, Franziska Roesner
-
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2020
   link: https://www.usenix.org/conference/usenixsecurity20
-  deadline: "2019-05-15"
+  deadline: '2019-05-15'
   note: Cycle 1/4
-  notification_date: "2019-08-19"
-  date: "2020-08-12"
+  notification_date: '2019-08-19'
+  date: '2020-08-12'
   place: Boston, MA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Srdjan Capkun, Franziska Roesner
-
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2019
   link: https://www.usenix.org/conference/usenixsecurity19
-  deadline: "2019-02-15"
+  deadline: '2019-02-15'
   note: Cycle 2/2
-  notification_date: "2019-05-01"
-  date: "2019-08-14"
+  notification_date: '2019-05-01'
+  date: '2019-08-14'
   place: Santa Clara, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Nadia Heninger, Patrick Traynor
-
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2019
   link: https://www.usenix.org/conference/usenixsecurity19
-  deadline: "2018-11-15"
+  deadline: '2018-11-15'
   note: Cycle 1/2
-  notification_date: "2019-01-18"
-  date: "2019-08-14"
+  notification_date: '2019-01-18'
+  date: '2019-08-14'
   place: Santa Clara, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Nadia Heninger, Patrick Traynor
-
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2018
   link: https://www.usenix.org/conference/usenixsecurity18
-  deadline: "2018-02-08"
-  note: 
-  notification_date: "2018-05-04"
-  date: "2018-08-15"
+  deadline: '2018-02-08'
+  note: null
+  notification_date: '2018-05-04'
+  date: '2018-08-15'
   place: Baltimore, MD
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: William Enck, Adrienne Porter Felt
-
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2017
   link: https://www.usenix.org/conference/usenixsecurity17
-  deadline: "2017-02-16"
-  note: 
-  notification_date: "2017-05-12"
-  date: "2017-08-16"
+  deadline: '2017-02-16'
+  note: null
+  notification_date: '2017-05-12'
+  date: '2017-08-16'
   place: Vancouver, BC, Canada
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Engin Kirda, Thomas Ristenpart
-
 - name: USENIX Security
   description: USENIX Security Symposium
   year: 2016
   link: https://www.usenix.org/conference/usenixsecurity16
-  deadline: "2016-02-18"
-  note: 
-  notification_date: "2016-05-16"
-  date: "2016-08-10"
+  deadline: '2016-02-18'
+  note: null
+  notification_date: '2016-05-16'
+  date: '2016-08-10'
   place: Austin, TX
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Thorsten Holz, Stefan Savage
-
 - name: NDSS
   description: Network and Distributed System Security Symposium
   year: 2026
   link: https://www.ndss-symposium.org/ndss2026/
-  deadline: "2025-08-06"
+  deadline: '2025-08-06'
   note: Cycle 2/2
-  abstract_deadline:
-  notification_date: "10-22-2025"
-  date: "2026-02-23"
+  abstract_deadline: null
+  notification_date: 10-22-2025
+  date: '2026-02-23'
   place: San Diego, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Heng Yin, Mauro Conti
   program_chair: Hamed Okhravi, Ivan Martinovic
-
+  series_link: https://ndss.org/
 - name: NDSS
   description: Network and Distributed System Security Symposium
   year: 2026
   link: https://www.ndss-symposium.org/ndss2026/
-  deadline: "2025-04-23"
+  deadline: '2025-04-23'
   note: Cycle 1/2
-  abstract_deadline:
-  notification_date: "07-02-2025"
-  date: "2026-02-23"
+  abstract_deadline: null
+  notification_date: 07-02-2025
+  date: '2026-02-23'
   place: San Diego, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Heng Yin, Mauro Conti
   program_chair: Hamed Okhravi, Ivan Martinovic
-
+  series_link: https://ndss.org/
 - name: NDSS
   description: Network and Distributed System Security Symposium
   year: 2025
   link: https://www.ndss-symposium.org/ndss2025/
-  deadline: "2024-09-15"
-  note: 
-  abstract_deadline: "2024-09-08"
-  date: "2025-02-24"
+  deadline: '2024-09-15'
+  note: null
+  abstract_deadline: '2024-09-08'
+  date: '2025-02-24'
   place: San Diego, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: David Balenson, Heng Yin
   program_chair: Christina Pöpper, Hamed Okhravi
-
+  series_link: https://ndss.org/
 - name: NDSS
   description: Network and Distributed System Security Symposium
   year: 2024
   link: https://www.ndss-symposium.org/ndss2024/
-  deadline: "2023-09-15"
-  note: 
-  abstract_deadline: "2023-09-08"
-  date: "2024-02-26"
+  deadline: '2023-09-15'
+  note: null
+  abstract_deadline: '2023-09-08'
+  date: '2024-02-26'
   place: San Diego, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Cristina Nita-Rotaru, Yongdae Kim
   program_chair: Mathias Payer, Christina Pöpper
-
+  series_link: https://ndss.org/
 - name: NDSS
   description: Network and Distributed System Security Symposium
   year: 2023
   link: https://www.ndss-symposium.org/ndss2023/
-  deadline: "2022-07-29"
+  deadline: '2022-07-29'
   note: Cycle 2/2
-  notification_date: "2022-10-21"
-  date: "2023-02-27"
+  notification_date: '2022-10-21'
+  date: '2023-02-27'
   place: San Diego, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Carrie Gates, Cristina Nita-Rotaru
   program_chair: Wenyuan Xu, Mathias Payer
-
+  series_link: https://ndss.org/
 - name: NDSS
   description: Network and Distributed System Security Symposium
   year: 2023
   link: https://www.ndss-symposium.org/ndss2023/
-  deadline: "2022-05-13"
+  deadline: '2022-05-13'
   note: Cycle 1/2
-  notification_date: "2022-07-27"
-  date: "2023-02-27"
+  notification_date: '2022-07-27'
+  date: '2023-02-27'
   place: San Diego, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Carrie Gates, Cristina Nita-Rotaru
   program_chair: Wenyuan Xu, Mathias Payer
-
+  series_link: https://ndss.org/
 - name: NDSS
   description: Network and Distributed System Security Symposium
   year: 2022
   link: https://www.ndss-symposium.org/ndss2022/
-  deadline: "2021-07-23"
+  deadline: '2021-07-23'
   note: Cycle 2/2
-  notification_date: "2021-10-29"
-  date: "2022-02-21"
+  notification_date: '2021-10-29'
+  date: '2022-02-21'
   place: San Diego, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Carrie Gates
   program_chair: Farinaz Koushanfar, Wenyuan Xu
-
+  series_link: https://ndss.org/
 - name: NDSS
   description: Network and Distributed System Security Symposium
   year: 2022
   link: https://www.ndss-symposium.org/ndss2022/
-  deadline: "2021-05-21"
+  deadline: '2021-05-21'
   note: Cycle 1/2
-  notification_date: "2021-08-06"
-  date: "2022-02-21"
+  notification_date: '2021-08-06'
+  date: '2022-02-21'
   place: San Diego, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Carrie Gates
   program_chair: Farinaz Koushanfar, Wenyuan Xu
-
+  series_link: https://ndss.org/
 - name: NDSS
   description: Network and Distributed System Security Symposium
   year: 2021
   link: https://www.ndss-symposium.org/ndss2021/
-  deadline: "2020-07-21"
+  deadline: '2020-07-21'
   note: Cycle 2/2
-  notification_date: "2020-10-23"
-  date: "2021-02-21"
+  notification_date: '2020-10-23'
+  date: '2021-02-21'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Trent Jaeger
   program_chair: Ahmad-Reza Sadeghi, Farinaz Koushanfar
-
+  series_link: https://ndss.org/
 - name: NDSS
   description: Network and Distributed System Security Symposium
   year: 2021
   link: https://www.ndss-symposium.org/ndss2021/
-  deadline: "2020-05-22"
+  deadline: '2020-05-22'
   note: Cycle 1/2
-  notification_date: "2020-08-07"
-  date: "2021-02-21"
+  notification_date: '2020-08-07'
+  date: '2021-02-21'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Trent Jaeger
   program_chair: Ahmad-Reza Sadeghi, Farinaz Koushanfar
-
+  series_link: https://ndss.org/
 - name: NDSS
   description: Network and Distributed System Security Symposium
   year: 2020
   link: https://www.ndss-symposium.org/ndss2020/
-  deadline: "2019-09-13"
+  deadline: '2019-09-13'
   note: Cycle 2/2
-  notification_date: "2019-12-08"
-  date: "2020-02-23"
+  notification_date: '2019-12-08'
+  date: '2020-02-23'
   place: San Diego, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Trent Jaeger
   program_chair: Ahmad-Reza Sadeghi, Dongyan Xu
-
+  series_link: https://ndss.org/
 - name: NDSS
   description: Network and Distributed System Security Symposium
   year: 2020
   link: https://www.ndss-symposium.org/ndss2020/
-  deadline: "2019-06-14"
+  deadline: '2019-06-14'
   note: Cycle 1/2
-  notification_date: "2019-08-25"
-  date: "2020-02-23"
+  notification_date: '2019-08-25'
+  date: '2020-02-23'
   place: San Diego, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Trent Jaeger
   program_chair: Ahmad-Reza Sadeghi, Dongyan Xu
-
+  series_link: https://ndss.org/
 - name: NDSS
   description: Network and Distributed System Security Symposium
   year: 2019
   link: https://www.ndss-symposium.org/ndss2019/
-  deadline: "2018-08-07"
-  note: 
-  notification_date: "2018-11-06"
-  date: "2019-02-24"
+  deadline: '2018-08-07'
+  note: null
+  notification_date: '2018-11-06'
+  date: '2019-02-24'
   place: San Diego, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Trent Jaeger
   program_chair: Alina Oprea, Dongyan Xu
-
+  series_link: https://ndss.org/
 - name: NDSS
   description: Network and Distributed System Security Symposium
   year: 2018
   link: https://www.ndss-symposium.org/ndss2018/
-  deadline: "2017-08-11"
-  note: 
-  date: "2018-02-18"
+  deadline: '2017-08-11'
+  note: null
+  date: '2018-02-18'
   place: San Diego, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Lujo Bauer
   program_chair: Patrick Traynor, Alina Oprea
-
+  series_link: https://ndss.org/
 - name: NDSS
   description: Network and Distributed System Security Symposium
   year: 2017
   link: https://www.ndss-symposium.org/ndss2017/
-  deadline: "2016-08-16"
-  note: 
-  abstract_deadline: "2016-08-12"
-  notification_date: "2016-10-22"
-  date: "2017-02-26"
+  deadline: '2016-08-16'
+  note: null
+  abstract_deadline: '2016-08-12'
+  notification_date: '2016-10-22'
+  date: '2017-02-26'
   place: San Diego, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Lujo Bauer
   program_chair: Ari Juels
-
+  series_link: https://ndss.org/
 - name: NDSS
   description: Network and Distributed System Security Symposium
   year: 2016
   link: https://www.ndss-symposium.org/ndss2016/
-  deadline: "2015-08-18"
-  note: 
-  abstract_deadline: "2015-08-14"
-  notification_date: "2015-10-22"
-  date: "2016-02-21"
+  deadline: '2015-08-18'
+  note: null
+  abstract_deadline: '2015-08-14'
+  notification_date: '2015-10-22'
+  date: '2016-02-21'
   place: San Diego, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Lujo Bauer
   program_chair: Srdjan Capkun, Deb Frincke
-
-## Databases
-
+  series_link: https://ndss.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2026
   link: https://2026.sigmod.org
-  abstract_deadline: "2025-01-10"
-  deadline: "2025-01-17"
+  abstract_deadline: '2025-01-10'
+  deadline: '2025-01-17'
   note: Cycle 1/4
-  notification_date: "2025-04-04"
-  date: "2026-05-31"
+  notification_date: '2025-04-04'
+  date: '2026-05-31'
   place: Bengaluru, India
-  program_chair:  Carsten Binnig, Sudeepa Roy
-  general_chair:  Jayant R. Haritsa,  S. Sudarshan
-
+  program_chair: Carsten Binnig, Sudeepa Roy
+  general_chair: Jayant R. Haritsa,  S. Sudarshan
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2026
   link: https://2026.sigmod.org
-  abstract_deadline: "2025-04-10"
-  deadline: "2025-04-17"
+  abstract_deadline: '2025-04-10'
+  deadline: '2025-04-17'
   note: Cycle 2/4
-  notification_date: "2025-07-04"
-  date: "2026-05-31"
-  place: "Bengaluru, India"
-  program_chair:  Carsten Binnig, Sudeepa Roy
-  general_chair:  Jayant R. Haritsa,  S. Sudarshan
-
-
+  notification_date: '2025-07-04'
+  date: '2026-05-31'
+  place: Bengaluru, India
+  program_chair: Carsten Binnig, Sudeepa Roy
+  general_chair: Jayant R. Haritsa,  S. Sudarshan
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2026
   link: https://2026.sigmod.org
-  abstract_deadline: "2025-07-10"
-  deadline: "2025-07-17"
+  abstract_deadline: '2025-07-10'
+  deadline: '2025-07-17'
   note: Cycle 3/4
-  notification_date: "2025-10-04"
-  date: "2026-05-31"
+  notification_date: '2025-10-04'
+  date: '2026-05-31'
   place: Bengaluru, India
-  program_chair:  Carsten Binnig, Sudeepa Roy
-  general_chair:  Jayant R. Haritsa,  S. Sudarshan
-
-
+  program_chair: Carsten Binnig, Sudeepa Roy
+  general_chair: Jayant R. Haritsa,  S. Sudarshan
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2026
   link: https://2025.sigmod.org
-  abstract_deadline: "2025-10-10"
-  deadline: "2025-10-17"
+  abstract_deadline: '2025-10-10'
+  deadline: '2025-10-17'
   note: Cycle 4/4
-  notification_date: "2026-01-04"
-  date: "2026-05-21"
+  notification_date: '2026-01-04'
+  date: '2026-05-21'
   place: Bengaluru, India
-  program_chair:  Carsten Binnig, Sudeepa Roy
-  general_chair:  Jayant R. Haritsa,  S. Sudarshan
-
-
+  program_chair: Carsten Binnig, Sudeepa Roy
+  general_chair: Jayant R. Haritsa,  S. Sudarshan
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2025
   link: https://2025.sigmod.org
-  abstract_deadline: "2024-01-10"
-  deadline: "2024-01-17"
+  abstract_deadline: '2024-01-10'
+  deadline: '2024-01-17'
   note: Cycle 1/4
-  notification_date: "2024-02-29"
-  date: "2025-06-22"
+  notification_date: '2024-02-29'
+  date: '2025-06-22'
   place: Berlin, Germany
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2025
   link: https://2025.sigmod.org
-  abstract_deadline: "2024-04-10"
-  deadline: "2024-10-17"
+  abstract_deadline: '2024-04-10'
+  deadline: '2024-10-17'
   note: Cycle 2/4
-  notification_date: "2024-05-30"
-  date: "2025-06-22"
+  notification_date: '2024-05-30'
+  date: '2025-06-22'
   place: Berlin, Germany
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2025
   link: https://2025.sigmod.org
-  abstract_deadline: "2024-07-10"
-  deadline: "2024-07-17"
+  abstract_deadline: '2024-07-10'
+  deadline: '2024-07-17'
   note: Cycle 3/4
-  notification_date: "2024-08-29"
-  date: "2025-06-22"
+  notification_date: '2024-08-29'
+  date: '2025-06-22'
   place: Berlin, Germany
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2025
   link: https://2025.sigmod.org
-  abstract_deadline: "2024-10-10"
-  deadline: "2024-10-17"
+  abstract_deadline: '2024-10-10'
+  deadline: '2024-10-17'
   note: Cycle 4/4
-  notification_date: "2024-11-28"
-  date: "2025-06-22"
+  notification_date: '2024-11-28'
+  date: '2025-06-22'
   place: Berlin, Germany
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2024
   link: https://2024.sigmod.org/
-  deadline: "2023-10-15"
+  deadline: '2023-10-15'
   note: Cycle 4/4
-  notification_date: "2023-12-20"
-  date: "2024-06-09"
+  notification_date: '2023-12-20'
+  date: '2024-06-09'
   place: Santiago, Chile
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2024
   link: https://2024.sigmod.org/
-  deadline: "2023-07-15"
+  deadline: '2023-07-15'
   note: Cycle 3/4
-  notification_date: "2023-09-04"
-  date: "2024-09-20"
+  notification_date: '2023-09-04'
+  date: '2024-09-20'
   place: Santiago, Chile
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2024
   link: https://2024.sigmod.org/
-  deadline: "2023-04-15"
+  deadline: '2023-04-15'
   note: Cycle 2/4
-  notification_date: "2023-06-29"
-  date: "2024-06-09"
+  notification_date: '2023-06-29'
+  date: '2024-06-09'
   place: Santiago, Chile
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2024
   link: https://2024.sigmod.org/
-  deadline: "2023-01-15"
+  deadline: '2023-01-15'
   note: Cycle 1/4
-  notification_date: "2023-03-20"
-  date: "2024-06-09"
+  notification_date: '2023-03-20'
+  date: '2024-06-09'
   place: Santiago, Chile
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2023
   link: https://2023.sigmod.org/
-  deadline: "2022-04-15"
+  deadline: '2022-04-15'
   note: Cycle 1/3
-  notification_date: "2022-06-20"
-  date: "2023-06-18"
+  notification_date: '2022-06-20'
+  date: '2023-06-18'
   place: Seattle, WA
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2023
   link: https://2023.sigmod.org/
-  deadline: "2022-07-15"
+  deadline: '2022-07-15'
   note: Cycle 2/3
-  notification_date: "2022-09-20"
-  date: "2023-06-18"
+  notification_date: '2022-09-20'
+  date: '2023-06-18'
   place: Seattle, WA
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2023
   link: https://2023.sigmod.org/
-  deadline: "2022-10-15"
+  deadline: '2022-10-15'
   note: Cycle 3/3
-  notification_date: "2022-12-20"
-  date: "2023-06-18"
+  notification_date: '2022-12-20'
+  date: '2023-06-18'
   place: Seattle, WA
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2022
   link: https://2022.sigmod.org/
-  deadline: "2021-07-02"
+  deadline: '2021-07-02'
   note: Cycle 1/2
-  notification_date: "2021-09-14"
-  date: "2022-06-12"
+  notification_date: '2021-09-14'
+  date: '2022-06-12'
   place: Philadelphia, PA
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2022
   link: https://2022.sigmod.org/
-  deadline: "2021-09-15"
+  deadline: '2021-09-15'
   note: Cycle 2/2
-  notification_date: "2021-12-06"
-  date: "2022-06-12"
+  notification_date: '2021-12-06'
+  date: '2022-06-12'
   place: Philadelphia, PA
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2021
   link: https://2021.sigmod.org/
-  deadline: "2020-07-07"
+  deadline: '2020-07-07'
   note: Cycle 1/2
-  notification_date: "2020-09-14"
-  date: "2021-06-20"
+  notification_date: '2020-09-14'
+  date: '2021-06-20'
   place: Xi'an, Shaanxi, China
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2021
   link: https://2021.sigmod.org/
-  deadline: "2020-09-22"
-  notification_date: "2020-11-30"
-  date: "2021-06-20"
+  deadline: '2020-09-22'
+  notification_date: '2020-11-30'
+  date: '2021-06-20'
   place: Xi'an, Shaanxi, China
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2020
   link: https://sigmod2020.org/
-  abstract_deadline: "2019-07-09"
-  deadline: "2019-07-16"
+  abstract_deadline: '2019-07-09'
+  deadline: '2019-07-16'
   note: Cycle 1/2
-  notification_date: "2019-10-03"
-  date: "2020-06-14"
+  notification_date: '2019-10-03'
+  date: '2020-06-14'
   place: Portland, OR
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2020
   link: https://sigmod2020.org/
-  abstract_deadline: "2019-10-15"
-  deadline: "2019-10-22"
+  abstract_deadline: '2019-10-15'
+  deadline: '2019-10-22'
   note: Cycle 2/2
-  notification_date: "2020-01-17"
-  date: "2020-06-14"
+  notification_date: '2020-01-17'
+  date: '2020-06-14'
   place: Portland, OR
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2019
   link: https://sigmod2019.org/
-  abstract_deadline: "2018-07-12"
-  deadline: "2018-07-19"
+  abstract_deadline: '2018-07-12'
+  deadline: '2018-07-19'
   note: Cycle 1/2
-  notification_date: "2018-10-05"
-  date: "2019-06-30"
+  notification_date: '2018-10-05'
+  date: '2019-06-30'
   place: Amsterdam, Netherlands
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2019
   link: https://sigmod2019.org/
-  abstract_deadline: "2018-10-18"
-  deadline: "2018-10-25"
+  abstract_deadline: '2018-10-18'
+  deadline: '2018-10-25'
   note: Cycle 2/2
-  notification_date: "2019-01-19"
-  date: "2019-06-30"
+  notification_date: '2019-01-19'
+  date: '2019-06-30'
   place: Amsterdam, Netherlands
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2018
   link: https://sigmod2018.org/
-  abstract_deadline: "2017-07-06"
-  deadline: "2017-07-13"
+  abstract_deadline: '2017-07-06'
+  deadline: '2017-07-13'
   note: Cycle 1/2
-  notification_date: "2017-09-20"
-  date: "2018-06-10"
+  notification_date: '2017-09-20'
+  date: '2018-06-10'
   place: Houston, TX
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2018
   link: https://sigmod2018.org/
-  abstract_deadline: "2017-10-26"
-  deadline: "2017-11-02"
+  abstract_deadline: '2017-10-26'
+  deadline: '2017-11-02'
   note: Cycle 2/2
-  notification_date: "2018-01-19"
-  date: "2018-06-10"
+  notification_date: '2018-01-19'
+  date: '2018-06-10'
   place: Houston, TX
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2017
   link: https://sigmod2017.org/
-  deadline: "2016-11-02"
-  notification_date: "2017-01-19"
-  date: "2017-05-14"
+  deadline: '2016-11-02'
+  notification_date: '2017-01-19'
+  date: '2017-05-14'
   place: Chicago, IL
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2016
   link: https://sigmod2016.org/
-  abstract_deadline: "2015-07-09"
-  deadline: "2015-07-16"
+  abstract_deadline: '2015-07-09'
+  deadline: '2015-07-16'
   note: Cycle 1/2
-  notification_date: "2015-08-18"
-  date: "2016-06-26"
+  notification_date: '2015-08-18'
+  date: '2016-06-26'
   place: San Francisco, CA
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2016
   link: https://sigmod2016.org/
-  abstract_deadline: "2015-11-12"
-  deadline: "2015-11-19"
+  abstract_deadline: '2015-11-12'
+  deadline: '2015-11-19'
   note: Cycle 2/2
-  notification_date: "2016-01-29"
-  date: "2016-06-26"
+  notification_date: '2016-01-29'
+  date: '2016-06-26'
   place: San Francisco, CA
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2015
   link: https://www.sigmod2015.org/
-  abstract_deadline: "2014-08-07"
-  deadline: "2014-08-14"
+  abstract_deadline: '2014-08-07'
+  deadline: '2014-08-14'
   note: Cycle 1/2
-  notification_date: "2014-10-16"
-  date: "2015-05-31"
+  notification_date: '2014-10-16'
+  date: '2015-05-31'
   place: Melbourne, Australia
-
+  series_link: https://sigmod.org/
 - name: SIGMOD
   description: ACM SIGMOD International Conference on Management of Data
   year: 2015
   link: https://www.sigmod2015.org/
-  abstract_deadline: "2014-10-30"
-  deadline: "2014-11-06"
+  abstract_deadline: '2014-10-30'
+  deadline: '2014-11-06'
   note: Cycle 2/2
-  notification_date: "2015-01-12"
-  date: "2015-05-31"
+  notification_date: '2015-01-12'
+  date: '2015-05-31'
   place: Melbourne, Australia
-
+  series_link: https://sigmod.org/
 - name: VLDB
   description: International Conference on Very Large Data Bases
   year: 2026
   link: https://vldb.org/2026/
-  deadline: "2026-03-01"
+  deadline: '2026-03-01'
   note: Rolling monthly deadlines until March 2026
-  abstract_deadline:
-  notification_date: "2026-03-15"
-  date: "2026-08-31"
+  abstract_deadline: null
+  notification_date: '2026-03-15'
+  date: '2026-08-31'
   place: Boston, MA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   program_chair: Yanlei Diao, Xiaokui Xiao
-
 - name: VLDB
   description: International Conference on Very Large Data Bases
   year: 2025
   link: https://vldb.org/2025/
-  deadline: "2025-03-01"
+  deadline: '2025-03-01'
   note: Rolling monthly deadlines until March 2025
-  abstract_deadline:
-  notification_date: "2025-03-15"
-  date: "2025-09-01"
+  abstract_deadline: null
+  notification_date: '2025-03-15'
+  date: '2025-09-01'
   place: London, UK
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
 - name: VLDB
   description: International Conference on Very Large Data Bases
   year: 2024
   link: https://vldb.org/2024/
-  deadline: "2024-03-01"
+  deadline: '2024-03-01'
   note: Rolling monthly deadlines until March 2024
-  abstract_deadline:
-  notification_date: "2024-03-15"
-  date: "2024-08-26"
+  abstract_deadline: null
+  notification_date: '2024-03-15'
+  date: '2024-08-26'
   place: Guangzhou, China
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
 - name: VLDB
   description: International Conference on Very Large Data Bases
   year: 2023
   link: https://vldb.org/2023/
-  deadline: "2023-03-01"
+  deadline: '2023-03-01'
   note: Rolling monthly deadlines until March 2023
-  abstract_deadline:
-  notification_date: "2023-03-15"
-  date: "2023-08-28"
+  abstract_deadline: null
+  notification_date: '2023-03-15'
+  date: '2023-08-28'
   place: Vancouver, Canada
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
 - name: VLDB
   description: International Conference on Very Large Data Bases
   year: 2022
   link: https://vldb.org/2022/
-  deadline: "2022-03-01"
+  deadline: '2022-03-01'
   note: Rolling monthly deadlines until March 2022
-  abstract_deadline:
-  notification_date: "2022-03-15"
-  date: "2022-09-05"
+  abstract_deadline: null
+  notification_date: '2022-03-15'
+  date: '2022-09-05'
   place: Sydney, Australia
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
 - name: VLDB
   description: International Conference on Very Large Data Bases
   year: 2021
   link: https://vldb.org/2021/
-  deadline: "2021-03-01"
+  deadline: '2021-03-01'
   note: Rolling monthly deadlines until March 2021
-  abstract_deadline:
-  notification_date: "2021-03-15"
-  date: "2021-08-16"
+  abstract_deadline: null
+  notification_date: '2021-03-15'
+  date: '2021-08-16'
   place: Copenhagen, Denmark
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
 - name: VLDB
   description: International Conference on Very Large Data Bases
   year: 2020
   link: https://vldb2020.org/
-  deadline: "2020-03-01"
+  deadline: '2020-03-01'
   note: Rolling monthly deadlines until March 2020
-  abstract_deadline:
-  notification_date: "2020-03-15"
-  date: "2020-08-31"
+  abstract_deadline: null
+  notification_date: '2020-03-15'
+  date: '2020-08-31'
   place: Tokyo, Japan
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
 - name: VLDB
   description: International Conference on Very Large Data Bases
   year: 2019
   link: https://vldb.org/2019/
-  deadline: "2019-03-01"
+  deadline: '2019-03-01'
   note: Rolling monthly deadlines until March 2019
-  abstract_deadline:
-  notification_date: "2019-03-15"
-  date: "2019-08-26"
+  abstract_deadline: null
+  notification_date: '2019-03-15'
+  date: '2019-08-26'
   place: Los Angeles, CA
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
 - name: VLDB
   description: International Conference on Very Large Data Bases
   year: 2018
   link: http://vldb2018.lncc.br/
-  deadline: "2018-03-01"
+  deadline: '2018-03-01'
   note: Rolling monthly deadlines until March 2018
-  abstract_deadline:
-  notification_date: "2018-03-15"
-  date: "2018-08-27"
+  abstract_deadline: null
+  notification_date: '2018-03-15'
+  date: '2018-08-27'
   place: Rio de Janeiro, Brazil
-  acceptance_rate: "21%"
-  num_submission: "1014"
-
+  acceptance_rate: 21%
+  num_submission: '1014'
 - name: VLDB
   description: International Conference on Very Large Data Bases
   year: 2017
   link: https://vldb.org/2017/
-  deadline: "2017-03-01"
+  deadline: '2017-03-01'
   note: Rolling monthly deadlines until March 2017
-  abstract_deadline:
-  notification_date: "2017-03-15"
-  date: "2017-08-28"
+  abstract_deadline: null
+  notification_date: '2017-03-15'
+  date: '2017-08-28'
   place: Munich, Germany
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
 - name: VLDB
   description: International Conference on Very Large Data Bases
   year: 2016
   link: http://vldb2016.persistent.com/
-  deadline: "2016-03-01"
+  deadline: '2016-03-01'
   note: Rolling monthly deadlines until March 2016
-  abstract_deadline:
-  notification_date: "2016-03-15"
-  date: "2016-09-05"
+  abstract_deadline: null
+  notification_date: '2016-03-15'
+  date: '2016-09-05'
   place: New Delhi, India
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
 - name: VLDB
   description: International Conference on Very Large Data Bases
   year: 2015
   link: https://vldb.org/2015/
-  deadline: "2015-03-01"
+  deadline: '2015-03-01'
   note: Rolling monthly deadlines until March 2015
-  abstract_deadline:
-  notification_date: "2015-03-15"
-  date: "2015-08-31"
+  abstract_deadline: null
+  notification_date: '2015-03-15'
+  date: '2015-08-31'
   place: Kohala Coast, HI
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
 - name: ICDE
   description: IEEE International Conference on Data Engineering
   year: 2026
   link: https://icde2026.github.io
   deadline: 2025-06-18
-  abstract_deadline: 
+  abstract_deadline: null
   notification_date: 2025-08-18
-  date: "2026-05-04"
+  date: '2026-05-04'
   place: Montreal, Canada
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Fei Chiang, Essam Mansour
   program_chair: Khuzaima Daudjee, Qiong Luo, Alkis Simitsis
-
 - name: ICDE
   description: IEEE International Conference on Data Engineering
   year: 2026
   link: https://icde2026.github.io
   deadline: 2025-10-27
-  abstract_deadline: 
+  abstract_deadline: null
   notification_date: 2025-12-22
-  date: "2026-05-04"
+  date: '2026-05-04'
   place: Montreal, Canada
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Fei Chiang, Essam Mansour
   program_chair: Khuzaima Daudjee, Qiong Luo, Alkis Simitsis
-
 - name: ICDE
   description: IEEE International Conference on Data Engineering
   year: 2025
   link: https://ieee-icde.org/2025/
   deadline: 2024-08-02
-  abstract_deadline: 
+  abstract_deadline: null
   notification_date: 2024-09-24
-  date: "2025-05-19"
+  date: '2025-05-19'
   place: Hong Kong SAR, China
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Xiaofang Zhou, Qing Li
   program_chair: Angela Bonifati, Wenjie Zhang, Hans-Arno Jacobsen
-
 - name: ICDE
   description: IEEE International Conference on Data Engineering
   year: 2025
   link: https://ieee-icde.org/2025/
   deadline: 2024-11-25
-  abstract_deadline: 
+  abstract_deadline: null
   notification_date: 2025-01-21
-  date: "2025-05-19"
+  date: '2025-05-19'
   place: Hong Kong SAR, China
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Xiaofang Zhou, Qing Li
   program_chair: Angela Bonifati, Wenjie Zhang, Hans-Arno Jacobsen
-
 - name: ICDE
   description: IEEE International Conference on Data Engineering
   year: 2024
   link: https://icde2024.github.io/
-  deadline: "2023-07-28"
-  abstract_deadline: 
-  notification_date: "2023-10-16"
+  deadline: '2023-07-28'
+  abstract_deadline: null
+  notification_date: '2023-10-16'
   date: 2024-05-13
   place: Utrecht, Netherlands
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Malu Castellanos, Yannis Velegrakis
   program_chair: Gautam Das, Timos Sellis, BingSheng He
-
 - name: ICDE
   description: IEEE International Conference on Data Engineering
   year: 2024
   link: https://icde2024.github.io/
-  deadline: "2023-12-03"
-  abstract_deadline: 
-  notification_date: "2024-02-09"
+  deadline: '2023-12-03'
+  abstract_deadline: null
+  notification_date: '2024-02-09'
   date: 2024-05-13
   place: Utrecht, Netherlands
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Malu Castellanos, Yannis Velegrakis
   program_chair: Gautam Das, Timos Sellis, BingSheng He
-
 - name: ICDE
   description: IEEE International Conference on Data Engineering
   year: 2023
   link: https://icde2023.ics.uci.edu/
   deadline: 2022-04-25
-  abstract_deadline: 
+  abstract_deadline: null
   notification_date: 2022-06-25
-  date: "2023-04-03"
+  date: '2023-04-03'
   place: Anaheim, CA
   note: Cycle 1/3
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Chen Li
   program_chair: Lei Chen, Stefan Manegold, Sharad Mehrotra
-
 - name: ICDE
   description: IEEE International Conference on Data Engineering
   year: 2023
   link: https://icde2023.ics.uci.edu/
   deadline: 2022-07-08
-  abstract_deadline: 
+  abstract_deadline: null
   notification_date: 2022-09-08
-  date: "2023-04-03"
+  date: '2023-04-03'
   place: Anaheim, CA
   note: Cycle 2/3
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Chen Li
   program_chair: Lei Chen, Stefan Manegold, Sharad Mehrotra
-
 - name: ICDE
   description: IEEE International Conference on Data Engineering
   year: 2023
   link: https://icde2023.ics.uci.edu/
   deadline: 2022-10-08
-  abstract_deadline: 
+  abstract_deadline: null
   notification_date: 2022-12-08
-  date: "2023-04-03"
+  date: '2023-04-03'
   place: Anaheim, CA
   note: Cycle 3/3
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Chen Li
   program_chair: Lei Chen, Stefan Manegold, Sharad Mehrotra
-
 - name: ICDE
   description: IEEE International Conference on Data Engineering
   year: 2022
   link: https://icde2022.ieeecomputer.my/
   deadline: 2021-07-21
-  abstract_deadline: 
+  abstract_deadline: null
   notification_date: 2021-09-01
-  date: "2022-05-09"
+  date: '2022-05-09'
   place: Kuala Lumpur, Malaysia (Virtual)
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Murat Kantarcioglu, Divesh Srivastava, Ali Selamat
   program_chair: Gao Cong, Stratos Idreos, Feifei Li
-
 - name: ICDE
   description: IEEE International Conference on Data Engineering
   year: 2022
   link: https://icde2022.ieeecomputer.my/
   deadline: 2021-11-19
-  abstract_deadline: 
+  abstract_deadline: null
   notification_date: 2022-01-14
-  date: "2022-05-09"
+  date: '2022-05-09'
   place: Kuala Lumpur, Malaysia (Virtual)
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Murat Kantarcioglu, Divesh Srivastava, Ali Selamat
   program_chair: Gao Cong, Stratos Idreos, Feifei Li
-
 - name: ICDE
   description: IEEE International Conference on Data Engineering
   year: 2021
-  link: 
-  deadline: 
-  abstract_deadline: 
-  notification_date: 
-  date: 
-  place: 
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  link: null
+  deadline: null
+  abstract_deadline: null
+  notification_date: null
+  date: null
+  place: null
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Anastasia Ailamaki, Minos Garofalakis
-
 - name: ICDE
   description: IEEE International Conference on Data Engineering
   year: 2020
@@ -4873,14 +4731,13 @@
   deadline: 2019-06-15
   abstract_deadline: 2019-06-08
   notification_date: 2019-08-10
-  date: "2020-04-20"
+  date: '2020-04-20'
   place: Dallas, TX
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Bhavani Thuraisingham, Elena Ferrari, Rao Kotagiri
   program_chair: Murat Kantarcioglu, Dimitrios Gunopulos, S. Sudarshan
-
 - name: ICDE
   description: IEEE International Conference on Data Engineering
   year: 2020
@@ -4888,44 +4745,41 @@
   deadline: 2019-10-15
   abstract_deadline: 2019-10-08
   notification_date: 2019-12-14
-  date: "2020-04-20"
+  date: '2020-04-20'
   place: Dallas, TX
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Bhavani Thuraisingham, Elena Ferrari, Rao Kotagiri
   program_chair: Murat Kantarcioglu, Dimitrios Gunopulos, S. Sudarshan
-
 - name: ICDE
   description: IEEE International Conference on Data Engineering
   year: 2019
   link: http://conferences.cis.umac.mo/icde2019/
   deadline: 2018-06-01
   abstract_deadline: 2018-05-25
-  notification_date: "2018-07-31"
-  date: "2019-04-08"
+  notification_date: '2018-07-31'
+  date: '2019-04-08'
   place: Macau SAR, China
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Christian S. Jensen, Lionel M. Ni, Tamer Özsu
   program_chair: Wenfei Fan, Xuemin Lin, Divesh Srivastava
-
 - name: ICDE
   description: IEEE International Conference on Data Engineering
   year: 2019
   link: http://conferences.cis.umac.mo/icde2019/
   deadline: 2018-10-15
   abstract_deadline: 2018-10-08
-  notification_date: "2018-12-14"
-  date: "2019-04-08"
+  notification_date: '2018-12-14'
+  date: '2019-04-08'
   place: Macau SAR, China
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Christian S. Jensen, Lionel M. Ni, Tamer Özsu
   program_chair: Wenfei Fan, Xuemin Lin, Divesh Srivastava
-
 - name: ICDE
   description: IEEE International Conference on Data Engineering
   year: 2018
@@ -4933,13 +4787,12 @@
   deadline: 2017-10-01
   abstract_deadline: 2017-09-22
   notification_date: 2017-12-22
-  date: "2018-04-16"
+  date: '2018-04-16'
   place: Paris, France
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Panos K. Chrysanthis
   program_chair: Stefan Manegold, Timos Sellis
-
 - name: ICDE
   description: IEEE International Conference on Data Engineering
   year: 2017
@@ -4947,118 +4800,115 @@
   deadline: 2016-10-18
   abstract_deadline: 2016-10-11
   notification_date: 2017-01-10
-  date: "2017-04-19"
+  date: '2017-04-19'
   place: San Diego, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Chaitanya Baru, Bhavani Thuraisingham
   program_chair: Yannis Papakonstantinou, Yanlei Diao
-
 - name: ICDE
   description: IEEE International Conference on Data Engineering
   year: 2016
-  link: 
-  deadline: 
-  abstract_deadline: 
-  notification_date: 
-  date: "2016-05-16"
+  link: null
+  deadline: null
+  abstract_deadline: null
+  notification_date: null
+  date: '2016-05-16'
   place: Helsinki, Finland
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2026
   link: https://2024.sigmod.org/
-  deadline: "2025-06-10"
-  abstract_deadline: "2025-06-03"
-  notification_date: "2025-08-11"
-  date: "2026-05-31"
+  deadline: '2025-06-10'
+  abstract_deadline: '2025-06-03'
+  notification_date: '2025-08-11'
+  date: '2026-05-31'
   place: Bengaluru, India
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Ke Yi
-
-
+  series_link: https://pods.org/
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2026
   link: https://2024.sigmod.org/
-  deadline: "2025-12-10"
-  abstract_deadline: "2025-12-03"
-  notification_date: "2026-02-08"
-  date: "2026-05-31"
+  deadline: '2025-12-10'
+  abstract_deadline: '2025-12-03'
+  notification_date: '2026-02-08'
+  date: '2026-05-31'
   place: Bengaluru, India
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Ke Yi
-
+  series_link: https://pods.org/
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2025
   link: https://2024.sigmod.org/
-  deadline: "2024-06-07"
-  abstract_deadline: "2024-05-31"
-  notification_date: "2024-08-12"
-  date: "2025-06-22"
+  deadline: '2024-06-07'
+  abstract_deadline: '2024-05-31'
+  notification_date: '2024-08-12'
+  date: '2025-06-22'
   place: Berlin, Germany
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://pods.org/
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2025
   link: https://2024.sigmod.org/
-  deadline: "2024-12-09"
-  abstract_deadline: "2024-12-02"
-  notification_date: "2025-02-14"
-  date: "2025-06-22"
+  deadline: '2024-12-09'
+  abstract_deadline: '2024-12-02'
+  notification_date: '2025-02-14'
+  date: '2025-06-22'
   place: Berlin, Germany
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://pods.org/
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2024
   link: https://2024.sigmod.org/
-  deadline: "2023-06-12"
-  abstract_deadline: "2023-06-06"
-  notification_date: "2024-09-04"
-  date: "2024-06-09"
+  deadline: '2023-06-12'
+  abstract_deadline: '2023-06-06'
+  notification_date: '2024-09-04'
+  date: '2024-06-09'
   place: Santiago, Chile
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://pods.org/
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2024
   link: https://2024.sigmod.org/
-  deadline: "2023-12-11"
-  abstract_deadline: "2023-12-04"
-  notification_date: "2024-02-09"
-  date: "2024-06-09"
+  deadline: '2023-12-11'
+  abstract_deadline: '2023-12-04'
+  notification_date: '2024-02-09'
+  date: '2024-06-09'
   place: Santiago, Chile
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://pods.org/
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2023
@@ -5066,14 +4916,14 @@
   deadline: 2022-06-06
   abstract_deadline: 2022-05-30
   notification_date: 2022-09-05
-  date: "2023-06-18"
+  date: '2023-06-18'
   place: Seattle, WA
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://pods.org/
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2023
@@ -5081,14 +4931,14 @@
   deadline: 2022-12-05
   abstract_deadline: 2022-11-28
   notification_date: 2023-03-03
-  date: "2023-06-18"
+  date: '2023-06-18'
   place: Seattle, WA
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://pods.org/
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2022
@@ -5096,14 +4946,14 @@
   deadline: 2021-06-18
   abstract_deadline: 2021-06-11
   notification_date: 2021-07-21
-  date: "2022-06-12"
+  date: '2022-06-12'
   place: Philadelphia, PA
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://pods.org/
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2022
@@ -5111,73 +4961,73 @@
   deadline: 2021-12-17
   abstract_deadline: 2021-12-10
   notification_date: 2022-02-28
-  date: "2022-06-12"
+  date: '2022-06-12'
   place: Philadelphia, PA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://pods.org/
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2021
   link: https://2021.sigmod.org/
-  deadline: "2020-07-07"
-  abstract_deadline: "2020-07-02"
-  notification_date: "2020-09-18"
-  date: "2021-06-20"
+  deadline: '2020-07-07'
+  abstract_deadline: '2020-07-02'
+  notification_date: '2020-09-18'
+  date: '2021-06-20'
   place: Xi'an, China (Virtual)
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://pods.org/
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2021
   link: https://2021.sigmod.org/
-  deadline: "2020-12-20"
-  abstract_deadline: "2020-12-13"
-  notification_date: "2021-03-05"
-  date: "2021-06-20"
+  deadline: '2020-12-20'
+  abstract_deadline: '2020-12-13'
+  notification_date: '2021-03-05'
+  date: '2021-06-20'
   place: Xi'an, China (Virtual)
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://pods.org/
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2020
   link: https://sigmod2020.org/
-  deadline: "2019-06-23"
-  abstract_deadline: "2019-06-15"
-  notification_date: "2020-09-01"
-  date: "2020-06-14"
+  deadline: '2019-06-23'
+  abstract_deadline: '2019-06-15'
+  notification_date: '2020-09-01'
+  date: '2020-06-14'
   place: Portland, OR (Virtual)
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://pods.org/
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2020
   link: https://sigmod2020.org/
-  deadline: "2019-12-22"
-  abstract_deadline: "2019-12-15"
-  notification_date: "2020-03-09"
-  date: "2020-06-14"
+  deadline: '2019-12-22'
+  abstract_deadline: '2019-12-15'
+  notification_date: '2020-03-09'
+  date: '2020-06-14'
   place: Portland, OR (Virtual)
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://pods.org/
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2019
@@ -5185,13 +5035,13 @@
   deadline: 2018-12-21
   abstract_deadline: 2018-12-14
   notification_date: 2019-03-08
-  date: "2019-06-30"
+  date: '2019-06-30'
   place: Amsterdam, The Netherlands
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://pods.org/
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2018
@@ -5199,14 +5049,14 @@
   deadline: 2017-06-22
   abstract_deadline: 2017-06-15
   notification_date: 2017-11-02
-  date: "2018-06-10"
+  date: '2018-06-10'
   place: Houston, TX
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://pods.org/
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2018
@@ -5214,14 +5064,14 @@
   deadline: 2017-12-19
   abstract_deadline: 2017-12-12
   notification_date: 2018-02-27
-  date: "2018-06-10"
+  date: '2018-06-10'
   place: Houston, TX
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://pods.org/
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2017
@@ -5229,14 +5079,14 @@
   deadline: 2016-07-22
   abstract_deadline: 2016-07-15
   notification_date: 2016-09-28
-  date: "2017-05-14"
+  date: '2017-05-14'
   place: Raleigh, NC
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://pods.org/
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2017
@@ -5244,44 +5094,44 @@
   deadline: 2016-11-11
   abstract_deadline: 2016-11-04
   notification_date: 2017-01-27
-  date: "2017-05-14"
+  date: '2017-05-14'
   place: Raleigh, NC
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://pods.org/
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2016
   link: https://sigmod2016.org/
-  deadline: "2015-10-09"
-  abstract_deadline: "2015-10-02"
-  notification_date: "2015-12-18"
-  date: "2016-06-26"
+  deadline: '2015-10-09'
+  abstract_deadline: '2015-10-02'
+  notification_date: '2015-12-18'
+  date: '2016-06-26'
   place: San Francisco, CA
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://pods.org/
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2016
   link: https://sigmod2016.org/
-  deadline: "2015-12-04"
-  abstract_deadline: "2015-11-27"
-  notification_date: "2016-03-04"
-  date: "2016-06-26"
+  deadline: '2015-12-04'
+  abstract_deadline: '2015-11-27'
+  notification_date: '2016-03-04'
+  date: '2016-06-26'
   place: San Francisco, CA
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://pods.org/
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2015
@@ -5289,14 +5139,14 @@
   deadline: 2014-10-10
   abstract_deadline: 2014-10-03
   notification_date: 2014-12-19
-  date: "2015-05-31"
+  date: '2015-05-31'
   place: Melbourne, Australia
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://pods.org/
 - name: PODS
   description: ACM Symposium on Principles of Database Systems
   year: 2015
@@ -5304,5289 +5154,5124 @@
   deadline: 2014-12-05
   abstract_deadline: 2014-11-28
   notification_date: 2015-02-20
-  date: "2015-05-31"
+  date: '2015-05-31'
   place: Melbourne, Australia
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
-
-
-## Design and Automation
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://pods.org/
 - name: DAC
   description: Design Automation Conference
   year: 2025
   link: https://www.dac.com/
-  deadline: "2024-11-19"
-  abstract_deadline: "2024-11-12"
-  notification_date: "2025-02-26"
-  date: "2025-06-22"
+  deadline: '2024-11-19'
+  abstract_deadline: '2024-11-12'
+  notification_date: '2025-02-26'
+  date: '2025-06-22'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://dac.org/
 - name: DAC
   description: Design Automation Conference
   year: 2024
   link: https://www.dac.com/
-  deadline: "2023-11-20"
-  abstract_deadline: "2023-11-13"
-  notification_date: "2024-02-26"
-  date: "2024-06-23"
+  deadline: '2023-11-20'
+  abstract_deadline: '2023-11-13'
+  notification_date: '2024-02-26'
+  date: '2024-06-23'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://dac.org/
 - name: DAC
   description: Design Automation Conference
   year: 2023
   link: https://www.dac.com/
-  deadline: 
-  abstract_deadline: 
-  notification_date: 
-  date: "2023-07-09"
+  deadline: null
+  abstract_deadline: null
+  notification_date: null
+  date: '2023-07-09'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://dac.org/
 - name: DAC
   description: Design Automation Conference
   year: 2022
   link: https://www.dac.com/
-  deadline: "2021-11-22"
-  abstract_deadline: "2021-11-15"
-  notification_date: "2022-02-21"
-  date: "2022-07-10"
+  deadline: '2021-11-22'
+  abstract_deadline: '2021-11-15'
+  notification_date: '2022-02-21'
+  date: '2022-07-10'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Rob Oshana
   program_chair: Vivek De
-
+  series_link: https://dac.org/
 - name: DAC
   description: Design Automation Conference
   year: 2021
   link: https://www.dac.com/
-  deadline: "2020-11-23"
-  abstract_deadline: "2020-11-16"
-  notification_date: "2021-02-24"
-  date: "2021-12-05"
+  deadline: '2020-11-23'
+  abstract_deadline: '2020-11-16'
+  notification_date: '2021-02-24'
+  date: '2021-12-05'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Harry Foster
   program_chair: Jörg Henkel
-
+  series_link: https://dac.org/
 - name: DAC
   description: Design Automation Conference
   year: 2020
   link: https://www.dac.com/
-  deadline: "2019-11-27"
-  abstract_deadline: "2019-11-21"
-  notification_date: "2020-02-28"
-  date: "2020-07-19"
+  deadline: '2019-11-27'
+  abstract_deadline: '2019-11-21'
+  notification_date: '2020-02-28'
+  date: '2020-07-19'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://dac.org/
 - name: DAC
   description: Design Automation Conference
   year: 2019
   link: https://www.dac.com/
-  deadline: "2018-11-27"
-  abstract_deadline: "2018-11-20"
-  notification_date: "2019-02-14"
-  date: "2019-06-02"
+  deadline: '2018-11-27'
+  abstract_deadline: '2018-11-20'
+  notification_date: '2019-02-14'
+  date: '2019-06-02'
   place: Las Vegas, NV
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://dac.org/
 - name: DAC
   description: Design Automation Conference
   year: 2018
   link: https://www.dac.com/
-  deadline: "2017-11-21"
-  abstract_deadline: "2017-11-14"
-  notification_date: 
-  date: "2018-06-24"
+  deadline: '2017-11-21'
+  abstract_deadline: '2017-11-14'
+  notification_date: null
+  date: '2018-06-24'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://dac.org/
 - name: DAC
   description: Design Automation Conference
   year: 2017
   link: https://www.dac.com/
-  deadline: 
-  abstract_deadline: 
-  notification_date: 
-  date: "2017-06-18"
+  deadline: null
+  abstract_deadline: null
+  notification_date: null
+  date: '2017-06-18'
   place: Austin, TX
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://dac.org/
 - name: DAC
   description: Design Automation Conference
   year: 2016
   link: https://www.dac.com/
-  deadline: "2015-11-24"
-  abstract_deadline: "2015-11-17"
-  notification_date: "2016-02-16"
-  date: "2016-06-05"
+  deadline: '2015-11-24'
+  abstract_deadline: '2015-11-17'
+  notification_date: '2016-02-16'
+  date: '2016-06-05'
   place: Austin, TX
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://dac.org/
 - name: ICCAD
   description: IEEE/ACM International Conference on Computer-Aided Design
   year: 2024
   link: https://2024.iccad.com/
-  deadline: "2024-05-05"
-  abstract_deadline: "2024-04-28"
-  notification_date: "2024-06-30"
-  date: "2024-10-27"
+  deadline: '2024-05-05'
+  abstract_deadline: '2024-04-28'
+  notification_date: '2024-06-30'
+  date: '2024-10-27'
   place: New York, NY
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://2025.iccad.com/
 - name: ICCAD
   description: IEEE/ACM International Conference on Computer-Aided Design
   year: 2023
   link: https://2023.iccad.com/
-  deadline: "2023-05-22"
-  abstract_deadline: "2023-05-15"
-  notification_date: "2023-07-21"
-  date: "2023-10-29"
+  deadline: '2023-05-22'
+  abstract_deadline: '2023-05-15'
+  notification_date: '2023-07-21'
+  date: '2023-10-29'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://2025.iccad.com/
 - name: ICCAD
   description: IEEE/ACM International Conference on Computer-Aided Design
   year: 2022
   link: https://www.iccad-conf.com/iccad2022/index.html
-  deadline: "2022-04-15"
-  abstract_deadline: 
-  notification_date: "2022-05-10"
-  date: "2022-07-13"
+  deadline: '2022-04-15'
+  abstract_deadline: null
+  notification_date: '2022-05-10'
+  date: '2022-07-13'
   place: Lisbon, Portugal
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://2025.iccad.com/
 - name: ICCAD
   description: IEEE/ACM International Conference on Computer-Aided Design
   year: 2021
   link: https://www.informatik.uni-bremen.de/iccad2021/index.php
-  deadline: "2021-05-28"
-  abstract_deadline: "2021-05-21"
-  notification_date: "2021-07-17"
-  date: "2021-11-01"
+  deadline: '2021-05-28'
+  abstract_deadline: '2021-05-21'
+  notification_date: '2021-07-17'
+  date: '2021-11-01'
   place: Munich, Germany
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Rolf Drechsler
-  program_chair: 
-
+  program_chair: null
+  series_link: https://2025.iccad.com/
 - name: ICCAD
   description: IEEE/ACM International Conference on Computer-Aided Design
   year: 2020
   link: https://www.iccad-conf.com/iccad2020/
-  deadline: "2020-06-30"
-  abstract_deadline: 
-  notification_date: "2020-07-31"
-  date: "2020-10-07"
+  deadline: '2020-06-30'
+  abstract_deadline: null
+  notification_date: '2020-07-31'
+  date: '2020-10-07'
   place: Paris, France
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://2025.iccad.com/
 - name: ICCAD
   description: IEEE/ACM International Conference on Computer-Aided Design
   year: 2019
   link: https://dblp.org/rec/conf/iccad/2019
-  deadline: "2019-01-31"
-  abstract_deadline: 
-  notification_date: "2019-03-31"
-  date: "2019-11-04"
+  deadline: '2019-01-31'
+  abstract_deadline: null
+  notification_date: '2019-03-31'
+  date: '2019-11-04'
   place: Westminster, CO
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: David Z. Pan
-  program_chair: 
-
+  program_chair: null
+  series_link: https://2025.iccad.com/
 - name: ICCAD
   description: IEEE/ACM International Conference on Computer-Aided Design
   year: 2018
   link: https://dblp.org/rec/conf/iccad/2018
-  deadline: "2018-06-04"
-  abstract_deadline: "2018-06-04"
-  notification_date: "2018-08-06"
-  date: "2018-11-05"
+  deadline: '2018-06-04'
+  abstract_deadline: '2018-06-04'
+  notification_date: '2018-08-06'
+  date: '2018-11-05'
   place: San Diego, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Iris Bahar
-  program_chair: 
-
+  program_chair: null
+  series_link: https://2025.iccad.com/
 - name: ICCAD
   description: IEEE/ACM International Conference on Computer-Aided Design
   year: 2017
   link: https://dblp.org/rec/conf/iccad/2017
-  deadline: "2017-06-28"
-  abstract_deadline: "2017-06-19"
-  notification_date: "2017-09-01"
-  date: "2017-11-13"
+  deadline: '2017-06-28'
+  abstract_deadline: '2017-06-19'
+  notification_date: '2017-09-01'
+  date: '2017-11-13'
   place: Irvine, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Sri Parameswaran
-  program_chair: 
-
+  program_chair: null
+  series_link: https://2025.iccad.com/
 - name: ICCAD
   description: IEEE/ACM International Conference on Computer-Aided Design
   year: 2016
   link: https://dblp.org/rec/conf/iccad/2016
-  deadline: "2016-02-01"
-  abstract_deadline: 
-  notification_date: "2016-05-06"
-  date: "2016-11-07"
+  deadline: '2016-02-01'
+  abstract_deadline: null
+  notification_date: '2016-05-06'
+  date: '2016-11-07'
   place: Austin, TX
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Frank Liu
-  program_chair: 
-
+  program_chair: null
+  series_link: https://2025.iccad.com/
 - name: ICCAD
   description: IEEE/ACM International Conference on Computer-Aided Design
   year: 2015
   link: https://dblp.org/rec/conf/iccad/2015
-  deadline: "2015-04-24"
-  abstract_deadline: 
-  notification_date: 
-  date: "2015-11-02"
+  deadline: '2015-04-24'
+  abstract_deadline: null
+  notification_date: null
+  date: '2015-11-02'
   place: Austin, TX
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Diana Marculescu
-  program_chair: 
-
-## Embedded and Real-Time Systems
-
+  program_chair: null
+  series_link: https://2025.iccad.com/
 - name: EMSOFT
   description: International Conference on Embedded Software
   year: 2025
   link: https://esweek.org/emsoft/
-  deadline: "2025-03-30"
-  abstract_deadline: "2025-03-23"
-  notification_date: "2025-05-18"
-  date: "2025-09-28"
+  deadline: '2025-03-30'
+  abstract_deadline: '2025-03-23'
+  notification_date: '2025-05-18'
+  date: '2025-09-28'
   place: Taipei, Taiwan
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Tei-Wei Kuo, Andy Pimentel
-  program_chair: Jeronimo Castrillon, Christophe Dubach, Prabhat Mishra, Paul Bogdan, Martina Maggio, Borzoo Bonakdarpour
-
-
+  program_chair: Jeronimo Castrillon, Christophe Dubach, Prabhat Mishra, Paul Bogdan,
+    Martina Maggio, Borzoo Bonakdarpour
 - name: EMSOFT
   description: International Conference on Embedded Software
   year: 2023
   link: https://esweek.org/emsoft/
-  deadline: "2023-03-23"
-  abstract_deadline: "2023-03-16"
-  notification_date: "2023-06-30"
-  date: "2023-09-17"
+  deadline: '2023-03-23'
+  abstract_deadline: '2023-03-16'
+  notification_date: '2023-06-30'
+  date: '2023-09-17'
   place: Hamburg, Germany
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Xiaobo Sharon Hu, Alain Girault
   program_chair: Claire Pagetti, Alessandro Biondi
-
 - name: EMSOFT
   description: International Conference on Embedded Software
   year: 2022
   link: https://esweek.org/emsoft/
-  deadline: "2022-04-07"
-  abstract_deadline: "2022-03-31"
-  notification_date: "2022-07-05"
-  date: "2022-10-07"
+  deadline: '2022-04-07'
+  abstract_deadline: '2022-03-31'
+  notification_date: '2022-07-05'
+  date: '2022-10-07'
   place: Hybrid (Shanghai, China)
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: David Broman, Claire Pagetti
-
 - name: EMSOFT
   description: International Conference on Embedded Software
   year: 2021
   link: https://esweek.org/emsoft/
-  deadline: "2021-04-09"
-  abstract_deadline: "2021-04-02"
-  notification_date: "2021-07-05"
-  date: "2021-10-10"
+  deadline: '2021-04-09'
+  abstract_deadline: '2021-04-02'
+  notification_date: '2021-07-05'
+  date: '2021-10-10'
   place: Virtual
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Andreas Gerstlauer, Aviral Shrivastava
   program_chair: Linh Thi Xuan Phan, David Broman
-
 - name: EMSOFT
   description: International Conference on Embedded Software
   year: 2020
   link: https://esweek.org/emsoft/
-  deadline: "2020-04-10"
-  abstract_deadline: "2020-04-03"
-  notification_date: "2020-07-06"
-  date: "2020-09-20"
+  deadline: '2020-04-10'
+  abstract_deadline: '2020-04-03'
+  notification_date: '2020-07-06'
+  date: '2020-09-20'
   place: Virtual
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Tulika Mitra, Andreas Gerstlauer
   program_chair: Timothy Roscoe, Björn B. Brandenburg
-
 - name: EMSOFT
   description: International Conference on Embedded Software
   year: 2019
   link: https://esweek.org/emsoft/
-  deadline: "2019-04-12"
-  abstract_deadline: "2019-04-05"
-  notification_date: "2019-07-10"
-  date: "2019-10-13"
+  deadline: '2019-04-12'
+  abstract_deadline: '2019-04-05'
+  notification_date: '2019-07-10'
+  date: '2019-10-13'
   place: New York City, NY
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: EMSOFT
   description: International Conference on Embedded Software
   year: 2018
   link: https://esweek.org/emsoft/
-  deadline: "2018-04-03"
-  abstract_deadline: "2018-03-27"
-  notification_date: "2018-07-06"
-  date: "2018-10-01"
+  deadline: '2018-04-03'
+  abstract_deadline: '2018-03-27'
+  notification_date: '2018-07-06'
+  date: '2018-10-01'
   place: Torino, Italy
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Zhonghai Lu, Sriram Vangal
   program_chair: Paul Bogdan, Jiang Xu
-
 - name: EMSOFT
   description: International Conference on Embedded Software
   year: 2017
   link: https://esweek.org/emsoft/
-  deadline: "2017-04-14"
-  abstract_deadline: "2017-04-07"
-  notification_date: "2017-07-07"
-  date: "2017-10-15"
+  deadline: '2017-04-14'
+  abstract_deadline: '2017-04-07'
+  notification_date: '2017-07-07'
+  date: '2017-10-15'
   place: Seoul, South Korea
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Lothar Thiele, Robert de Simone
-
 - name: EMSOFT
   description: International Conference on Embedded Software
   year: 2016
   link: https://esweek.org/emsoft/
-  deadline: "2016-04-08"
-  abstract_deadline: "2016-04-01"
-  notification_date: "2016-07-01"
-  date: "2016-10-02"
+  deadline: '2016-04-08'
+  abstract_deadline: '2016-04-01'
+  notification_date: '2016-07-01'
+  date: '2016-10-02'
   place: Pittsburgh, PA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Petru Eles, Rahul Mangharam
-
 - name: EMSOFT
   description: International Conference on Embedded Software
   year: 2015
   link: https://esweek.org/emsoft/
-  deadline: "2015-03-30"
-  abstract_deadline: "2015-03-23"
-  notification_date: "2015-06-11"
-  date: "2015-10-04"
+  deadline: '2015-03-30'
+  abstract_deadline: '2015-03-23'
+  notification_date: '2015-06-11'
+  date: '2015-10-04'
   place: Amsterdam, The Netherlands
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Alain Girault, Nan Guan
-
 - name: EMSOFT
   description: International Conference on Embedded Software
   year: 2014
   link: https://esweek.org/emsoft/
-  deadline: "2014-04-04"
-  abstract_deadline: "2014-03-28"
-  notification_date: "2014-06-27"
-  date: "2014-10-12"
+  deadline: '2014-04-04'
+  abstract_deadline: '2014-03-28'
+  notification_date: '2014-06-27'
+  date: '2014-10-12'
   place: New Delhi, India
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Tulika Mitra, Jan Reineke
-
 - name: RTAS
   description: IEEE Real-Time and Embedded Technology and Applications Symposium
   year: 2024
   link: https://2024.rtas.org/
-  deadline: "2023-10-31"
-  abstract_deadline: 
-  notification_date: "2024-01-20"
-  date: "2024-05-13"
+  deadline: '2023-10-31'
+  abstract_deadline: null
+  notification_date: '2024-01-20'
+  date: '2024-05-13'
   place: Hong Kong
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Iain Bate
   program_chair: Benny Akesson
-
 - name: RTAS
   description: IEEE Real-Time and Embedded Technology and Applications Symposium
   year: 2023
   link: https://2023.rtas.org/
-  deadline: "2022-10-31"
-  abstract_deadline: 
-  notification_date: "2023-01-20"
-  date: "2023-05-09"
+  deadline: '2022-10-31'
+  abstract_deadline: null
+  notification_date: '2023-01-20'
+  date: '2023-05-09'
   place: San Antonio, TX
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Heechul Yun
   program_chair: Iain Bate
-
 - name: RTAS
   description: IEEE Real-Time and Embedded Technology and Applications Symposium
   year: 2022
   link: https://2022.rtas.org/
-  deadline: "2021-10-29"
-  abstract_deadline: 
-  notification_date: "2022-01-17"
-  date: "2022-05-04"
+  deadline: '2021-10-29'
+  abstract_deadline: null
+  notification_date: '2022-01-17'
+  date: '2022-05-04'
   place: Milano, Italy (Virtual)
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Nan Guan
   program_chair: Heechul Yun
-
 - name: RTAS
   description: IEEE Real-Time and Embedded Technology and Applications Symposium
   year: 2021
   link: https://2021.rtas.org/
-  deadline: "2020-10-26"
-  abstract_deadline: 
-  notification_date: "2021-01-17"
-  date: "2021-05-18"
+  deadline: '2020-10-26'
+  abstract_deadline: null
+  notification_date: '2021-01-17'
+  date: '2021-05-18'
   place: Virtual
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Nan Guan
-
 - name: RTAS
   description: IEEE Real-Time and Embedded Technology and Applications Symposium
   year: 2020
   link: https://2020.rtas.org/
-  deadline: "2019-10-23"
-  abstract_deadline: 
-  notification_date: "2019-12-20"
-  date: "2020-04-21"
+  deadline: '2019-10-23'
+  abstract_deadline: null
+  notification_date: '2019-12-20'
+  date: '2020-04-21'
   place: Sydney, Australia (Virtual)
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: RTAS
   description: IEEE Real-Time and Embedded Technology and Applications Symposium
   year: 2019
   link: https://2019.rtas.org/
-  deadline: "2018-10-17"
-  abstract_deadline: 
-  notification_date: "2018-12-21"
-  date: "2019-04-16"
+  deadline: '2018-10-17'
+  abstract_deadline: null
+  notification_date: '2018-12-21'
+  date: '2019-04-16'
   place: Montreal, Canada
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: RTAS
   description: IEEE Real-Time and Embedded Technology and Applications Symposium
   year: 2018
   link: https://2018.rtas.org/
-  deadline: "2017-10-06"
-  abstract_deadline: 
-  notification_date: "2017-12-19"
-  date: "2018-04-10"
+  deadline: '2017-10-06'
+  abstract_deadline: null
+  notification_date: '2017-12-19'
+  date: '2018-04-10'
   place: Porto, Portugal
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: RTAS
   description: IEEE Real-Time and Embedded Technology and Applications Symposium
   year: 2017
   link: https://2017.rtas.org/
-  deadline: "2016-10-13"
-  abstract_deadline: 
-  notification_date: "2016-12-20"
-  date: "2017-04-18"
+  deadline: '2016-10-13'
+  abstract_deadline: null
+  notification_date: '2016-12-20'
+  date: '2017-04-18'
   place: Pittsburgh, PA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: RTAS
   description: IEEE Real-Time and Embedded Technology and Applications Symposium
   year: 2016
   link: https://2016.rtas.org/
-  deadline: "2015-10-15"
-  abstract_deadline: 
-  notification_date: "2015-12-14"
-  date: "2016-04-11"
+  deadline: '2015-10-15'
+  abstract_deadline: null
+  notification_date: '2015-12-14'
+  date: '2016-04-11'
   place: Vienna, Austria
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: RTAS
   description: IEEE Real-Time and Embedded Technology and Applications Symposium
   year: 2015
   link: https://2015.rtas.org/
-  deadline: "2014-10-20"
-  abstract_deadline: "2014-10-13"
-  notification_date: "2014-12-13"
-  date: "2015-04-14"
+  deadline: '2014-10-20'
+  abstract_deadline: '2014-10-13'
+  notification_date: '2014-12-13'
+  date: '2015-04-14'
   place: Seattle, WA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: RTSS
   description: IEEE Real-Time Systems Symposium
   year: 2025
   link: https://2025.rtss.org/
-  deadline: "2025-05-22"
-  abstract_deadline: 
-  notification_date: "2025-07-25"
-  date: "2025-12-02"
+  deadline: '2025-05-22'
+  abstract_deadline: null
+  notification_date: '2025-07-25'
+  date: '2025-12-02'
   place: Boston, MA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Rich West
   program_chair: Björn Brandenburg
-
 - name: RTSS
   description: IEEE Real-Time Systems Symposium
   year: 2024
   link: https://2024.rtss.org
-  deadline: "2024-05-23"
-  abstract_deadline: 
-  notification_date: "2024-07-31"
-  date: "2024-12-10"
+  deadline: '2024-05-23'
+  abstract_deadline: null
+  notification_date: '2024-07-31'
+  date: '2024-12-10'
   place: York, UK
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Eduardo Tovar
-  program_chair: 
-
+  program_chair: null
 - name: RTSS
   description: IEEE Real-Time Systems Symposium
   year: 2023
   link: https://2023.rtss.org/
-  deadline: "2023-05-25"
-  abstract_deadline: 
-  notification_date: "2023-04-04"
-  date: "2023-12-05"
+  deadline: '2023-05-25'
+  abstract_deadline: null
+  notification_date: '2023-04-04'
+  date: '2023-12-05'
   place: Taipei, Taiwan
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jian-Jia Chen
   program_chair: Insik Shin
-
 - name: RTSS
   description: IEEE Real-Time Systems Symposium
   year: 2022
   link: http://2022.rtss.org/
-  deadline: "2022-05-26"
-  abstract_deadline: 
-  notification_date: "2022-08-05"
-  date: "2022-12-05"
+  deadline: '2022-05-26'
+  abstract_deadline: null
+  notification_date: '2022-08-05'
+  date: '2022-12-05'
   place: Houston, TX
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Liliana Cucu-Grosjean
   program_chair: Arvind Easwaran
-
 - name: RTSS
   description: IEEE Real-Time Systems Symposium
   year: 2021
   link: http://2021.rtss.org
-  deadline: "2021-05-27"
-  abstract_deadline: 
-  notification_date: "2021-08-06"
-  date: "2021-12-07"
+  deadline: '2021-05-27'
+  abstract_deadline: null
+  notification_date: '2021-08-06'
+  date: '2021-12-07'
   place: Online
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jian-Jia Chen
   program_chair: Enrico Bini
-
 - name: RTSS
   description: IEEE Real-Time Systems Symposium
   year: 2020
   link: http://2020.rtss.org/
-  deadline: "2020-07-02"
-  abstract_deadline: 
-  notification_date: "2020-09-14"
-  date: "2020-12-01"
+  deadline: '2020-07-02'
+  abstract_deadline: null
+  notification_date: '2020-09-14'
+  date: '2020-12-01'
   place: Online
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: X. Sharon Hu
   program_chair: Jian-Jia Chen
-
 - name: RTSS
   description: IEEE Real-Time Systems Symposium
   year: 2019
   link: https://2019.rtss.org
-  deadline: "2019-05-30"
-  abstract_deadline: 
-  notification_date: "2019-08-05"
+  deadline: '2019-05-30'
+  abstract_deadline: null
+  notification_date: '2019-08-05'
   date: Cancelled
   place: Hong Kong (Cancelled)
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Robert Davis
   program_chair: X. Sharon Hu
-
 - name: RTSS
   description: IEEE Real-Time Systems Symposium
   year: 2018
   link: https://2018.rtss.org/
-  deadline: "2018-05-31"
-  abstract_deadline: 
-  notification_date: "2018-08-03"
-  date: "2018-12-11"
+  deadline: '2018-05-31'
+  abstract_deadline: null
+  notification_date: '2018-08-03'
+  date: '2018-12-11'
   place: Nashville, TN
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Isabelle Puaut
   program_chair: Robert Davis
-
 - name: RTSS
   description: IEEE Real-Time Systems Symposium
   year: 2017
   link: https://2017.rtss.org
-  deadline: "2017-05-01"
-  abstract_deadline: 
-  notification_date: "2017-07-10"
-  date: "2017-12-05"
+  deadline: '2017-05-01'
+  abstract_deadline: null
+  notification_date: '2017-07-10'
+  date: '2017-12-05'
   place: Paris, France
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Frank Mueller
   program_chair: Isabelle Puaut
-
 - name: RTSS
   description: IEEE Real-Time Systems Symposium
   year: 2016
   link: https://2016.rtss.org
-  deadline: "2016-05-04"
-  abstract_deadline: 
-  notification_date: "2016-07-15"
-  date: "2016-11-29"
+  deadline: '2016-05-04'
+  abstract_deadline: null
+  notification_date: '2016-07-15'
+  date: '2016-11-29'
   place: Porto, Portugal
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Marco Caccamo
   program_chair: Frank Mueller
-
 - name: RTSS
   description: IEEE Real-Time Systems Symposium
   year: 2015
   link: https://2015.rtss.org
-  deadline: "2015-05-15"
-  abstract_deadline: 
-  notification_date: "2015-07-20"
-  date: "2015-12-01"
+  deadline: '2015-05-15'
+  abstract_deadline: null
+  notification_date: '2015-07-20'
+  date: '2015-12-01'
   place: San Antonio, TX
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Christopher D. Gill
-  program_chair: Marco Caccamo  
-
-# High-performance computing
-
+  program_chair: Marco Caccamo
 - name: HPDC
-  description: ACM International Symposium on High-Performance Parallel and Distributed Computing
+  description: ACM International Symposium on High-Performance Parallel and Distributed
+    Computing
   year: 2024
   link: http://hpdc.org/2024/
-  deadline: "2024-01-25"
-  abstract_deadline: 
-  notification_date: "2024-03-25"
-  date: "2024-06-03"
+  deadline: '2024-01-25'
+  abstract_deadline: null
+  notification_date: '2024-03-25'
+  date: '2024-06-03'
   place: Pisa, Italy
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: HPDC
-  description: ACM International Symposium on High-Performance Parallel and Distributed Computing
+  description: ACM International Symposium on High-Performance Parallel and Distributed
+    Computing
   year: 2023
   link: http://hpdc.org/2023/
-  deadline: "2023-01-27"
-  abstract_deadline: 
-  notification_date: "2023-03-29"
-  date: "2023-06-16"
+  deadline: '2023-01-27'
+  abstract_deadline: null
+  notification_date: '2023-03-29'
+  date: '2023-06-16'
   place: Orlando, FL
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: HPDC
-  description: ACM International Symposium on High-Performance Parallel and Distributed Computing
+  description: ACM International Symposium on High-Performance Parallel and Distributed
+    Computing
   year: 2022
   link: https://hpdc.org/2022/
-  deadline: "2022-01-27"
-  abstract_deadline: "2022-01-20"
-  notification_date: "2022-03-31"
-  date: "2022-06-27"
+  deadline: '2022-01-27'
+  abstract_deadline: '2022-01-20'
+  notification_date: '2022-03-31'
+  date: '2022-06-27'
   place: Minneapolis, MN
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jon Weissman, Abhishek Chandra
   program_chair: Ada Gavrilovska, Devesh Tiwari
-
 - name: HPDC
-  description: ACM International Symposium on High-Performance Parallel and Distributed Computing
+  description: ACM International Symposium on High-Performance Parallel and Distributed
+    Computing
   year: 2021
   link: https://hpdc.org/2021/
-  deadline: "2021-01-24"
-  abstract_deadline: "2021-01-18"
-  notification_date: "2021-03-29"
-  date: "2021-06-21"
+  deadline: '2021-01-24'
+  abstract_deadline: '2021-01-18'
+  notification_date: '2021-03-29'
+  date: '2021-06-21'
   place: Online
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Erwin Laure, Stefano Markidis
-  program_chair: 
-
+  program_chair: null
 - name: HPDC
-  description: ACM International Symposium on High-Performance Parallel and Distributed Computing
+  description: ACM International Symposium on High-Performance Parallel and Distributed
+    Computing
   year: 2020
   link: https://hpdc.org/2020/
-  deadline: "2020-01-23"
-  abstract_deadline: "2020-01-16"
-  notification_date: "2020-03-27"
-  date: "2020-06-23"
+  deadline: '2020-01-23'
+  abstract_deadline: '2020-01-16'
+  notification_date: '2020-03-27'
+  date: '2020-06-23'
   place: Stockholm, Sweden
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Manish Parashar, Vladimir Vlassov
-  program_chair: 
-
+  program_chair: null
 - name: HPDC
-  description: ACM International Symposium on High-Performance Parallel and Distributed Computing
+  description: ACM International Symposium on High-Performance Parallel and Distributed
+    Computing
   year: 2019
   link: https://hpdc.org/2019/
-  deadline: "2019-01-23"
-  abstract_deadline: "2019-01-16"
-  notification_date: "2019-03-25"
-  date: "2019-06-24"
+  deadline: '2019-01-23'
+  abstract_deadline: '2019-01-16'
+  notification_date: '2019-03-25'
+  date: '2019-06-24'
   place: Phoenix, AZ
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jon Weissman
   program_chair: Ali R. Butt, Evgenia Smirni
-
 - name: HPDC
-  description: ACM International Symposium on High-Performance Parallel and Distributed Computing
+  description: ACM International Symposium on High-Performance Parallel and Distributed
+    Computing
   year: 2018
   link: https://hpdc.org/2018/
-  deadline: "2018-01-24"
-  abstract_deadline: "2018-01-17"
-  notification_date: "2018-03-26"
-  date: "2018-06-11"
+  deadline: '2018-01-24'
+  abstract_deadline: '2018-01-17'
+  notification_date: '2018-03-26'
+  date: '2018-06-11'
   place: Tempe, AZ
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Ming Zhao
-  program_chair: 
-
+  program_chair: null
 - name: HPDC
-  description: ACM International Symposium on High-Performance Parallel and Distributed Computing
+  description: ACM International Symposium on High-Performance Parallel and Distributed
+    Computing
   year: 2017
   link: https://hpdc.org/2017/
-  deadline: "2017-01-17"
-  abstract_deadline: "2017-01-10"
-  notification_date: "2017-03-29"
-  date: "2017-06-26"
+  deadline: '2017-01-17'
+  abstract_deadline: '2017-01-10'
+  notification_date: '2017-03-29'
+  date: '2017-06-26'
   place: Washington, DC
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Howie Huang
-  program_chair: 
-
+  program_chair: null
 - name: HPDC
-  description: ACM International Symposium on High-Performance Parallel and Distributed Computing
+  description: ACM International Symposium on High-Performance Parallel and Distributed
+    Computing
   year: 2016
   link: https://hpdc.org/2016/
-  deadline: "2016-01-18"
-  abstract_deadline: "2016-01-11"
-  notification_date: "2016-03-12"
-  date: "2016-05-31"
+  deadline: '2016-01-18'
+  abstract_deadline: '2016-01-11'
+  notification_date: '2016-03-12'
+  date: '2016-05-31'
   place: Kyoto, Japan
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Hiroshi Nakashima
   program_chair: Kenjiro Taura, Jack Lange
-
 - name: HPDC
-  description: ACM International Symposium on High-Performance Parallel and Distributed Computing
+  description: ACM International Symposium on High-Performance Parallel and Distributed
+    Computing
   year: 2015
   link: https://hpdc.org/2015/
-  deadline: "2015-01-19"
-  abstract_deadline: "2015-01-12"
-  notification_date: "2015-03-16"
-  date: "2015-06-15"
+  deadline: '2015-01-19'
+  abstract_deadline: '2015-01-12'
+  notification_date: '2015-03-16'
+  date: '2015-06-15'
   place: Portland, OR
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Thilo Kielmann
   program_chair: Dean Hildebrand, Michela Taufer
-  
-# Mobile computing
-
 - name: MobiCom
   description: ACM International Conference on Mobile Computing and Networking
   year: 2026
   link: https://www.sigmobile.org/mobicom/2024/
-  deadline: "2025-09-03"
-  abstract_deadline: "2025-08-27"
-  notification_date: "2025-11-24"
-  rebuttal_date: "2026-11-11"
-  date: "2026-11-26"
+  deadline: '2025-09-03'
+  abstract_deadline: '2025-08-27'
+  notification_date: '2025-11-24'
+  rebuttal_date: '2026-11-11'
+  date: '2026-11-26'
   place: Austin, Texas, USA
-  note:
-  acceptance_rate:
-  num_submission:
+  note: null
+  acceptance_rate: null
+  num_submission: null
   general_chair: Kaushik Chowdhury
   program_chair: Mahesh Marina, Fan Bai
-
-
 - name: MobiCom
   description: ACM International Conference on Mobile Computing and Networking
   year: 2024
   link: https://www.sigmobile.org/mobicom/2024/
-  deadline: "2023-08-25"
-  abstract_deadline: "2023-08-18"
-  notification_date: "2023-10-13"
-  date: "2024-11-18"
+  deadline: '2023-08-25'
+  abstract_deadline: '2023-08-18'
+  notification_date: '2023-10-13'
+  date: '2024-11-18'
   place: Washington, D.C., USA
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Weisong Shi
-  program_chair: 
-
+  program_chair: null
 - name: MobiCom
   description: ACM International Conference on Mobile Computing and Networking
   year: 2024
   link: https://www.sigmobile.org/mobicom/2024/
-  deadline: "2024-03-15"
-  abstract_deadline: "2024-03-08"
-  notification_date: "2024-03-10"
-  date: "2024-11-18"
+  deadline: '2024-03-15'
+  abstract_deadline: '2024-03-08'
+  notification_date: '2024-03-10'
+  date: '2024-11-18'
   place: Washington, D.C., USA
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Weisong Shi
-  program_chair: 
-
+  program_chair: null
 - name: MobiCom
   description: ACM International Conference on Mobile Computing and Networking
   year: 2023
   link: https://www.sigmobile.org/mobicom/2023/
-  deadline: "2022-08-19"
-  abstract_deadline: "2022-08-12"
-  notification_date: "2022-10-07"
-  date: "2023-10-02"
+  deadline: '2022-08-19'
+  abstract_deadline: '2022-08-12'
+  notification_date: '2022-10-07'
+  date: '2023-10-02'
   place: Madrid, Spain
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Joerg Widmer, Xavier Costa-Pérez
-  program_chair: 
-
+  program_chair: null
 - name: MobiCom
   description: ACM International Conference on Mobile Computing and Networking
   year: 2023
   link: https://www.sigmobile.org/mobicom/2023/
-  deadline: "2023-03-17"
-  abstract_deadline: "2023-03-10"
-  notification_date: "2023-05-08"
-  date: "2023-10-02"
+  deadline: '2023-03-17'
+  abstract_deadline: '2023-03-10'
+  notification_date: '2023-05-08'
+  date: '2023-10-02'
   place: Madrid, Spain
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
-  general_chair:  Joerg Widmer, Xavier Costa-Pérez
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Joerg Widmer, Xavier Costa-Pérez
+  program_chair: null
 - name: MobiCom
   description: ACM International Conference on Mobile Computing and Networking
   year: 2022
   link: https://www.sigmobile.org/mobicom/2022/
-  deadline: "2021-08-20"
-  abstract_deadline: "2021-08-13"
-  notification_date: "2021-11-14"
-  date: "2022-10-17"
+  deadline: '2021-08-20'
+  abstract_deadline: '2021-08-13'
+  notification_date: '2021-11-14'
+  date: '2022-10-17'
   place: Sydney, Australia
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Tao Gu, Aruna Seneviratne
-  program_chair: 
-
+  program_chair: null
 - name: MobiCom
   description: ACM International Conference on Mobile Computing and Networking
   year: 2022
   link: https://www.sigmobile.org/mobicom/2022/
-  deadline: "2022-03-25"
-  abstract_deadline: "2022-03-18"
-  notification_date: "2022-06-10"
-  date: "2022-10-17"
+  deadline: '2022-03-25'
+  abstract_deadline: '2022-03-18'
+  notification_date: '2022-06-10'
+  date: '2022-10-17'
   place: Sydney, Australia
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Tao Gu, Aruna Seneviratne
-  program_chair: 
-
+  program_chair: null
 - name: MobiCom
   description: ACM International Conference on Mobile Computing and Networking
   year: 2021
   link: https://www.sigmobile.org/mobicom/2021/
-  deadline: "2020-08-21"
-  abstract_deadline: "2020-08-14"
-  notification_date: "2020-11-13"
-  date: "2021-03-28"
+  deadline: '2020-08-21'
+  abstract_deadline: '2020-08-14'
+  notification_date: '2020-11-13'
+  date: '2021-03-28'
   place: New Orleans, LA, USA
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: David B. Johnson
-  program_chair: 
-
+  program_chair: null
 - name: MobiCom
   description: ACM International Conference on Mobile Computing and Networking
   year: 2021
   link: https://www.sigmobile.org/mobicom/2021/
-  deadline: "2021-03-26"
-  abstract_deadline: "2021-03-19"
-  notification_date: "2021-06-11"
-  date: "2021-03-28"
+  deadline: '2021-03-26'
+  abstract_deadline: '2021-03-19'
+  notification_date: '2021-06-11'
+  date: '2021-03-28'
   place: New Orleans, LA, USA
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: David B. Johnson
-  program_chair: 
-
+  program_chair: null
 - name: MobiCom
   description: ACM International Conference on Mobile Computing and Networking
   year: 2020
   link: https://www.sigmobile.org/mobicom/2020/
-  deadline: "2020-03-26"
-  abstract_deadline: "2020-03-21"
-  notification_date: 
-  date: "2020-09-21"
+  deadline: '2020-03-26'
+  abstract_deadline: '2020-03-21'
+  notification_date: null
+  date: '2020-09-21'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jon Crowcroft, Hamed Haddadi
-  program_chair: 
-
+  program_chair: null
 - name: MobiCom
   description: ACM International Conference on Mobile Computing and Networking
   year: 2019
   link: https://www.sigmobile.org/mobicom/2019/
-  deadline: "2019-03-22"
-  abstract_deadline: "2019-03-15"
-  notification_date: "2019-06-14"
-  date: "2019-10-21"
+  deadline: '2019-03-22'
+  abstract_deadline: '2019-03-15'
+  notification_date: '2019-06-14'
+  date: '2019-10-21'
   place: Los Cabos, Mexico
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Sharad Agarwal, Ben Greenstein
-  program_chair: 
-
+  program_chair: null
 - name: MobiCom
   description: ACM International Conference on Mobile Computing and Networking
   year: 2018
   link: https://www.sigmobile.org/mobicom/2018/
-  deadline: "2018-03-13"
-  abstract_deadline: "2018-03-06"
-  notification_date: "2018-03-24"
-  date: "2018-10-29"
+  deadline: '2018-03-13'
+  abstract_deadline: '2018-03-06'
+  notification_date: '2018-03-24'
+  date: '2018-10-29'
   place: New Delhi, India
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Rajeev Shorey, Rohan Murty
   program_chair: YingYing (Jennifer) Chen, Kyle Jamieson
-
 - name: MobiCom
   description: ACM International Conference on Mobile Computing and Networking
   year: 2017
   link: https://www.sigmobile.org/mobicom/2017/
-  deadline: "2017-03-16"
-  abstract_deadline: "2017-03-09"
-  notification_date: "2017-06-08"
-  date: "2017-10-16"
+  deadline: '2017-03-16'
+  abstract_deadline: '2017-03-09'
+  notification_date: '2017-06-08'
+  date: '2017-10-16'
   place: Snowbird, Utah, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: Kobus Van der Merwe 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Kobus Van der Merwe
   program_chair: Ben Greenstein, Kannan Srinivasan
-
 - name: MobiCom
   description: ACM International Conference on Mobile Computing and Networking
   year: 2016
   link: https://www.sigmobile.org/mobicom/2016/
-  deadline: "2016-03-15"
-  abstract_deadline: "2016-03-08"
-  notification_date: "2016-06-13"
-  date: "2016-10-03"
+  deadline: '2016-03-15'
+  abstract_deadline: '2016-03-08'
+  notification_date: '2016-06-13'
+  date: '2016-10-03'
   place: New York City, NY, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: Yingying Chen, Marco Gruteser 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Yingying Chen, Marco Gruteser
   program_chair: Y. Charlie Hu, Karthik Sundaresan
-
 - name: MobiCom
   description: ACM International Conference on Mobile Computing and Networking
   year: 2015
   link: https://www.sigmobile.org/mobicom/2015/
-  deadline: "2015-03-11"
-  abstract_deadline: "2015-03-04"
-  notification_date: "2015-06-05"
-  date: "2015-09-07"
+  deadline: '2015-03-11'
+  abstract_deadline: '2015-03-04'
+  notification_date: '2015-06-05'
+  date: '2015-09-07'
   place: Paris, France
-  acceptance_rate: 
-  num_submission: 
-  general_chair: Serge Fdida, Giovanni Pau 
-  program_chair: Sneha Kumar Kasera, Heather Zheng 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Serge Fdida, Giovanni Pau
+  program_chair: Sneha Kumar Kasera, Heather Zheng
 - name: MobiSys
   description: ACM International Conference on Mobile Systems, Applications, and Services
   year: 2026
   link: https://www.sigmobile.org/mobisys/2026/
-  deadline: "2025-12-05"
-  abstract_deadline: "2025-11-28"
-  rebuttal_date: "2026-02-09"
-  notification_date: "2026-03-02"
-  note: 
-  date: "2026-06-21"
+  deadline: '2025-12-05'
+  abstract_deadline: '2025-11-28'
+  rebuttal_date: '2026-02-09'
+  notification_date: '2026-03-02'
+  note: null
+  date: '2026-06-21'
   place: Cambridge, UK
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Fahim Kawsar, Cecilia Mascolo
   program_chair: Fadel Adib, Youngki Lee
-
 - name: MobiSys
   description: ACM International Conference on Mobile Systems, Applications, and Services
   year: 2025
   link: https://www.sigmobile.org/mobisys/2025/
-  deadline: "2024-12-09"
-  abstract_deadline: "2024-12-02"
-  notification_date: "2025-01-20"
-  date: "2025-06-23"
+  deadline: '2024-12-09'
+  abstract_deadline: '2024-12-02'
+  notification_date: '2025-01-20'
+  date: '2025-06-23'
   place: Anaheim, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Ardalan Amiri Sani, Chenren Xu
   program_chair: Swarun Kumar, Przemysław Pawełczak
-
 - name: MobiSys
   description: ACM International Conference on Mobile Systems, Applications, and Services
   year: 2024
   link: https://www.sigmobile.org/mobisys/2024/
-  deadline: "2023-11-30"
-  abstract_deadline: "2023-11-23"
-  notification_date: "2024-03-06"
-  date: "2024-06-04"
+  deadline: '2023-11-30'
+  abstract_deadline: '2023-11-23'
+  notification_date: '2024-03-06'
+  date: '2024-06-04'
   place: Tokyo, Japan
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Tadashi Okoshi, JeongGil Ko
-  program_chair: 
-
+  program_chair: null
 - name: MobiSys
   description: ACM International Conference on Mobile Systems, Applications, and Services
   year: 2023
   link: https://www.sigmobile.org/mobisys/2023/
-  deadline: "2022-12-09"
-  abstract_deadline: 
-  notification_date: "2023-02-27"
-  date: "2023-06-18"
+  deadline: '2022-12-09'
+  abstract_deadline: null
+  notification_date: '2023-02-27'
+  date: '2023-06-18'
   place: Helsinki, Finland
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Petteri Nurmi, Pan Hui
   program_chair: Ardalan Amiri Sani, Yunxin Liu
-
 - name: MobiSys
   description: ACM International Conference on Mobile Systems, Applications, and Services
   year: 2022
   link: https://www.sigmobile.org/mobisys/2022/
-  deadline: "2021-12-20"
-  abstract_deadline: "2021-12-13"
-  notification_date: "2022-03-14"
-  date: "2022-06-27"
+  deadline: '2021-12-20'
+  abstract_deadline: '2021-12-13'
+  notification_date: '2022-03-14'
+  date: '2022-06-27'
   place: Portland, Oregon, USA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Nirupama Bulusu
   program_chair: Aruna Balasubramanian, Junehwa Song
-
 - name: MobiSys
   description: ACM International Conference on Mobile Systems, Applications, and Services
   year: 2021
   link: https://www.sigmobile.org/mobisys/2021/
-  deadline: "2021-01-15"
-  abstract_deadline: "2021-01-08"
-  notification_date: "2021-03-25"
-  date: "2021-06-24"
+  deadline: '2021-01-15'
+  abstract_deadline: '2021-01-08'
+  notification_date: '2021-03-25'
+  date: '2021-06-24'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Suman Banerjee
   program_chair: Luca Mottola, Xia Zhou
-
 - name: MobiSys
   description: ACM International Conference on Mobile Systems, Applications, and Services
   year: 2020
   link: https://www.sigmobile.org/mobisys/2020/
-  deadline: "2019-12-12"
-  abstract_deadline: "2019-12-05"
-  notification_date: "2020-03-09"
-  date: "2020-06-16"
+  deadline: '2019-12-12'
+  abstract_deadline: '2019-12-05'
+  notification_date: '2020-03-09'
+  date: '2020-06-16'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Eyal de Lara, Iqbal Mohomed
   program_chair: Jason Nieh, Elizabeth M. Belding
-
 - name: MobiSys
   description: ACM International Conference on Mobile Systems, Applications, and Services
   year: 2019
   link: https://www.sigmobile.org/mobisys/2019/
-  deadline: "2018-12-14"
-  abstract_deadline: "2018-12-07"
-  notification_date: "2019-03-09"
-  date: "2019-06-17"
+  deadline: '2018-12-14'
+  abstract_deadline: '2018-12-07'
+  notification_date: '2019-03-09'
+  date: '2019-06-17'
   place: Seoul, South Korea
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Junehwa Song, Minkyong Kim
   program_chair: Nicholas D. Lane, Rajesh K. Balan
-
 - name: MobiSys
   description: ACM International Conference on Mobile Systems, Applications, and Services
   year: 2018
   link: https://www.sigmobile.org/mobisys/2018/
-  deadline: "2017-12-08"
-  abstract_deadline: "2017-12-01"
-  notification_date: "2018-03-02"
-  date: "2018-06-10"
+  deadline: '2017-12-08'
+  abstract_deadline: '2017-12-01'
+  notification_date: '2018-03-02'
+  date: '2018-06-10'
   place: Munich, Germany
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Joerg Ott, Falko Dressler
   program_chair: Stefan Saroiu, Prabal Dutta
-
 - name: MobiSys
   description: ACM International Conference on Mobile Systems, Applications, and Services
   year: 2017
   link: https://www.sigmobile.org/mobisys/2017/
-  deadline: "2016-12-08"
-  abstract_deadline: "2016-12-01"
-  notification_date: "2017-03-01"
-  date: "2017-06-19"
+  deadline: '2016-12-08'
+  abstract_deadline: '2016-12-01'
+  notification_date: '2017-03-01'
+  date: '2017-06-19'
   place: Niagara Falls, NY, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: Tanzeem Choudhury, Steve Ko 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Tanzeem Choudhury, Steve Ko
   program_chair: Andrew Campbell, Deepak Ganesan
-
 - name: MobiSys
   description: ACM International Conference on Mobile Systems, Applications, and Services
   year: 2016
   link: https://www.sigmobile.org/mobisys/2016/
-  deadline: "2015-12-09"
-  abstract_deadline: "2015-12-02"
-  notification_date: "2016-03-01"
-  date: "2016-06-26"
+  deadline: '2015-12-09'
+  abstract_deadline: '2015-12-02'
+  notification_date: '2016-03-01'
+  date: '2016-06-26'
   place: Singapore
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Rajesh Balan, Archan Misra
   program_chair: Sharad Agarwal, Cecilia Mascolo
-
 - name: MobiSys
   description: ACM International Conference on Mobile Systems, Applications, and Services
   year: 2015
   link: https://www.sigmobile.org/mobisys/2015/
-  deadline: "2014-12-05"
-  abstract_deadline: "2014-11-28"
-  notification_date: "2015-02-16"
-  date: "2015-05-18"
+  deadline: '2014-12-05'
+  abstract_deadline: '2014-11-28'
+  notification_date: '2015-02-16'
+  date: '2015-05-18'
   place: Florence, Italy
-  acceptance_rate: 
-  num_submission: 
-  general_chair: Gaetano Borriello, Giovanni Pau 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Gaetano Borriello, Giovanni Pau
   program_chair: Marco Gruteser, Jason Hong
-
-
-
-# Measurement & perf. analysis 
-
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2025
   link: https://www.sigmetrics.org/sigmetrics2025/
-  deadline: "2024-08-07"
-  abstract_deadline: "2024-07-31"
-  notification_date: "2024-09-24"
-  date: "2025-06-09"
+  deadline: '2024-08-07'
+  abstract_deadline: '2024-07-31'
+  notification_date: '2024-09-24'
+  date: '2025-06-09'
   place: Stony Brook, NY, USA
   note: Cycle 1/3
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Anshul Gandhi, Zhenhua Liu
   program_chair: Sewoong Oh, Ramesh Sitaraman, Benny Van Houdt
-
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2025
   link: https://www.sigmetrics.org/sigmetrics2025/
-  deadline: "2024-10-09"
-  abstract_deadline: "2024-10-02"
-  notification_date: "2024-12-10"
-  date: "2025-06-09"
+  deadline: '2024-10-09'
+  abstract_deadline: '2024-10-02'
+  notification_date: '2024-12-10'
+  date: '2025-06-09'
   place: Stony Brook, NY, USA
   note: Cycle 2/3
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Anshul Gandhi, Zhenhua Liu
   program_chair: Sewoong Oh, Ramesh Sitaraman, Benny Van Houdt
-
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2025
   link: https://www.sigmetrics.org/sigmetrics2025/
-  deadline: "2025-01-22"
-  abstract_deadline: "2025-01-15"
-  notification_date: "2025-03-18"
-  date: "2025-06-09"
+  deadline: '2025-01-22'
+  abstract_deadline: '2025-01-15'
+  notification_date: '2025-03-18'
+  date: '2025-06-09'
   place: Stony Brook, NY, USA
   note: Cycle 3/3
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Anshul Gandhi, Zhenhua Liu
   program_chair: Sewoong Oh, Ramesh Sitaraman, Benny Van Houdt
-
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2024
   link: https://www.sigmetrics.org/sigmetrics2024/
-  deadline: "2023-08-09"
-  abstract_deadline: "2023-08-02"
-  notification_date: "2023-09-26"
-  date: "2024-06-10"
+  deadline: '2023-08-09'
+  abstract_deadline: '2023-08-02'
+  notification_date: '2023-09-26'
+  date: '2024-06-10'
   place: Venice, Italy
   note: Cycle 1/3
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Andrea Marin, Michele Garetto
   program_chair: Giulia Fanti, Florin Ciucu, Rhonda Righter
-
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2024
   link: https://www.sigmetrics.org/sigmetrics2024/
-  deadline: "2023-10-11"
-  abstract_deadline: "2023-10-04"
-  notification_date: "2023-12-12"
-  date: "2024-06-10"
+  deadline: '2023-10-11'
+  abstract_deadline: '2023-10-04'
+  notification_date: '2023-12-12'
+  date: '2024-06-10'
   place: Venice, Italy
   note: Cycle 2/3
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Andrea Marin, Michele Garetto
   program_chair: Giulia Fanti, Florin Ciucu, Rhonda Righter
-
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2024
   link: https://www.sigmetrics.org/sigmetrics2024/
-  deadline: "2024-01-31"
-  abstract_deadline: "2024-01-24"
-  notification_date: "2024-03-26"
-  date: "2024-06-10"
+  deadline: '2024-01-31'
+  abstract_deadline: '2024-01-24'
+  notification_date: '2024-03-26'
+  date: '2024-06-10'
   place: Venice, Italy
   note: Cycle 3/3
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Andrea Marin, Michele Garetto
   program_chair: Giulia Fanti, Florin Ciucu, Rhonda Righter
-
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2023
   link: https://www.sigmetrics.org/sigmetrics2023/
-  deadline: "2022-08-10"
-  abstract_deadline: "2022-08-03"
-  notification_date: "2022-10-04"
-  date: "2023-06-19"
+  deadline: '2022-08-10'
+  abstract_deadline: '2022-08-03'
+  notification_date: '2022-10-04'
+  date: '2023-06-19'
   place: Orlando, FL, USA
   note: Cycle 1/3
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Evgenia Smirni
   program_chair: Konstantin Avrachenkov, Phillipa Gill, Bhuvan Urgaonkar
-
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2023
   link: https://www.sigmetrics.org/sigmetrics2023/
-  deadline: "2022-10-19"
-  abstract_deadline: "2022-10-12"
-  notification_date: "2022-12-20"
-  date: "2023-06-19"
+  deadline: '2022-10-19'
+  abstract_deadline: '2022-10-12'
+  notification_date: '2022-12-20'
+  date: '2023-06-19'
   place: Orlando, FL, USA
   note: Cycle 2/3
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Evgenia Smirni
   program_chair: Konstantin Avrachenkov, Phillipa Gill, Bhuvan Urgaonkar
-
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2023
   link: https://www.sigmetrics.org/sigmetrics2023/
-  deadline: "2023-02-01"
-  abstract_deadline: "2023-01-25"
-  notification_date: "2023-03-28"
-  date: "2023-06-19"
+  deadline: '2023-02-01'
+  abstract_deadline: '2023-01-25'
+  notification_date: '2023-03-28'
+  date: '2023-06-19'
   place: Orlando, FL, USA
   note: Cycle 3/3
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Evgenia Smirni
   program_chair: Konstantin Avrachenkov, Phillipa Gill, Bhuvan Urgaonkar
-
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2022
   link: https://www.sigmetrics.org/sigmetrics2022/
-  deadline: "2021-08-11"
-  abstract_deadline: "2021-08-04"
-  notification_date: "2021-10-04"
-  date: "2022-06-06"
+  deadline: '2021-08-11'
+  abstract_deadline: '2021-08-04'
+  notification_date: '2021-10-04'
+  date: '2022-06-06'
   place: Mumbai, India
   note: Cycle 1/3
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: D Manjunath, Jayakrishnan Nair
   program_chair: Niklas Carlsson, Edith Cohen, Philippe Robert
-
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2022
   link: https://www.sigmetrics.org/sigmetrics2022/
-  deadline: "2021-10-20"
-  abstract_deadline: "2021-10-13"
-  notification_date: "2021-12-13"
-  date: "2022-06-06"
+  deadline: '2021-10-20'
+  abstract_deadline: '2021-10-13'
+  notification_date: '2021-12-13'
+  date: '2022-06-06'
   place: Mumbai, India
   note: Cycle 2/3
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: D Manjunath, Jayakrishnan Nair
   program_chair: Niklas Carlsson, Edith Cohen, Philippe Robert
-
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2022
   link: https://www.sigmetrics.org/sigmetrics2022/
-  deadline: "2022-02-03"
-  abstract_deadline: "2022-01-26"
-  notification_date: "2022-03-28"
-  date: "2022-06-06"
+  deadline: '2022-02-03'
+  abstract_deadline: '2022-01-26'
+  notification_date: '2022-03-28'
+  date: '2022-06-06'
   place: Mumbai, India
   note: Cycle 3/3
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: D Manjunath, Jayakrishnan Nair
   program_chair: Niklas Carlsson, Edith Cohen, Philippe Robert
-
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2021
   link: https://www.sigmetrics.org/sigmetrics2021/
-  deadline: "2020-08-07"
-  abstract_deadline: "2020-07-31"
-  notification_date: "2020-09-29"
-  date: "2021-06-14"
+  deadline: '2020-08-07'
+  abstract_deadline: '2020-07-31'
+  notification_date: '2020-09-29'
+  date: '2021-06-14'
   place: Virtual Conference
   note: Cycle 1/3
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Longbo Huang
-  program_chair: Anshul Gandhi, Negar Kiyavash, Jia Wang 
-
+  program_chair: Anshul Gandhi, Negar Kiyavash, Jia Wang
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2021
   link: https://www.sigmetrics.org/sigmetrics2021/
-  deadline: "2020-10-23"
-  abstract_deadline: "2020-10-16"
-  notification_date: "2020-12-15"
-  date: "2021-06-14"
+  deadline: '2020-10-23'
+  abstract_deadline: '2020-10-16'
+  notification_date: '2020-12-15'
+  date: '2021-06-14'
   place: Virtual Conference
   note: Cycle 2/3
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Longbo Huang
-  program_chair: Anshul Gandhi, Negar Kiyavash, Jia Wang  
-
+  program_chair: Anshul Gandhi, Negar Kiyavash, Jia Wang
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2021
   link: https://www.sigmetrics.org/sigmetrics2021/
-  deadline: "2021-02-05"
-  abstract_deadline: "2021-01-29"
-  notification_date: "2021-03-30"
-  date: "2021-06-14"
+  deadline: '2021-02-05'
+  abstract_deadline: '2021-01-29'
+  notification_date: '2021-03-30'
+  date: '2021-06-14'
   place: Virtual Conference
   note: Cycle 3/3
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Longbo Huang
-  program_chair: Anshul Gandhi, Negar Kiyavash, Jia Wang 
-
+  program_chair: Anshul Gandhi, Negar Kiyavash, Jia Wang
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2020
   link: https://www.sigmetrics.org/sigmetrics2020/
-  deadline: "2019-08-08"
-  abstract_deadline: "2019-08-01"
-  notification_date: "2019-09-30"
-  date: "2020-06-08"
+  deadline: '2019-08-08'
+  abstract_deadline: '2019-08-01'
+  notification_date: '2019-09-30'
+  date: '2020-06-08'
   place: Boston, MA, USA
   note: Cycle 1/3
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Edmund Yeh
   program_chair: Athina Markopoulou, Y.C. Tay
-
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2020
   link: https://www.sigmetrics.org/sigmetrics2020/
-  deadline: "2019-10-21"
-  abstract_deadline: "2019-10-14"
-  notification_date: "2019-12-16"
-  date: "2020-06-08"
+  deadline: '2019-10-21'
+  abstract_deadline: '2019-10-14'
+  notification_date: '2019-12-16'
+  date: '2020-06-08'
   place: Boston, MA, USA
   note: Cycle 2/3
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Edmund Yeh
   program_chair: Athina Markopoulou, Y.C. Tay
-
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2020
   link: https://www.sigmetrics.org/sigmetrics2020/
-  deadline: "2020-02-03"
-  abstract_deadline: "2020-01-27"
-  notification_date: "2020-03-31"
-  date: "2020-06-08"
+  deadline: '2020-02-03'
+  abstract_deadline: '2020-01-27'
+  notification_date: '2020-03-31'
+  date: '2020-06-08'
   place: Boston, MA, USA
   note: Cycle 3/3
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Edmund Yeh
   program_chair: Athina Markopoulou, Y.C. Tay
-
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2019
   link: https://www.sigmetrics.org/sigmetrics2019/
-  deadline: "2018-08-20"
-  abstract_deadline: "2018-08-13"
-  notification_date: "2018-10-08"
-  date: "2019-06-24"
+  deadline: '2018-08-20'
+  abstract_deadline: '2018-08-13'
+  notification_date: '2018-10-08'
+  date: '2019-06-24'
   place: Phoenix, AZ, USA
   note: Cycle 1/3
-  acceptance_rate: 
-  num_submission: 
-  general_chair: Erich Nahum 
-  program_chair: Thomas Bonald, Nick Duffield 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Erich Nahum
+  program_chair: Thomas Bonald, Nick Duffield
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2019
   link: https://www.sigmetrics.org/sigmetrics2019/
-  deadline: "2018-10-29"
-  abstract_deadline: "2018-10-22"
-  notification_date: "2018-12-17"
-  date: "2019-06-24"
+  deadline: '2018-10-29'
+  abstract_deadline: '2018-10-22'
+  notification_date: '2018-12-17'
+  date: '2019-06-24'
   place: Phoenix, AZ, USA
   note: Cycle 2/3
-  acceptance_rate: 
-  num_submission: 
-  general_chair: Erich Nahum 
-  program_chair: Thomas Bonald, Nick Duffield 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Erich Nahum
+  program_chair: Thomas Bonald, Nick Duffield
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2019
   link: https://www.sigmetrics.org/sigmetrics2019/
-  deadline: "2019-02-18"
-  abstract_deadline: "2019-02-11"
-  notification_date: "2019-04-26"
-  date: "2019-06-24"
+  deadline: '2019-02-18'
+  abstract_deadline: '2019-02-11'
+  notification_date: '2019-04-26'
+  date: '2019-06-24'
   place: Phoenix, AZ, USA
   note: Cycle 3/3
-  acceptance_rate: 
-  num_submission: 
-  general_chair: Erich Nahum 
-  program_chair: Thomas Bonald, Nick Duffield 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Erich Nahum
+  program_chair: Thomas Bonald, Nick Duffield
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2018
   link: https://www.sigmetrics.org/sigmetrics2018/
-  deadline: "2017-07-17"
-  abstract_deadline: "2017-07-10"
-  notification_date: "2017-09-22"
-  date: "2018-06-18"
+  deadline: '2017-07-17'
+  abstract_deadline: '2017-07-10'
+  notification_date: '2017-09-22'
+  date: '2018-06-18'
   place: Irvine, CA, USA
   note: Cycle 1/3
-  acceptance_rate: 
-  num_submission: 
-  general_chair: Konstantinos Psounis 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Konstantinos Psounis
   program_chair: Aditya Akella, Adam Wierman
-
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2018
   link: https://www.sigmetrics.org/sigmetrics2018/
-  deadline: "2017-10-23"
-  abstract_deadline: "2017-10-16"
-  notification_date: "2017-12-15"
-  date: "2018-06-18"
+  deadline: '2017-10-23'
+  abstract_deadline: '2017-10-16'
+  notification_date: '2017-12-15'
+  date: '2018-06-18'
   place: Irvine, CA, USA
   note: Cycle 2/3
-  acceptance_rate: 
-  num_submission: 
-  general_chair: Konstantinos Psounis 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Konstantinos Psounis
   program_chair: Aditya Akella, Adam Wierman
-
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2018
   link: https://www.sigmetrics.org/sigmetrics2018/
-  deadline: "2018-02-19"
-  abstract_deadline: "2018-02-12"
-  notification_date: "2108-04-27"
-  date: "2018-06-18"
+  deadline: '2018-02-19'
+  abstract_deadline: '2018-02-12'
+  notification_date: '2108-04-27'
+  date: '2018-06-18'
   place: Irvine, CA, USA
   note: Cycle 3/3
-  acceptance_rate: 
-  num_submission: 
-  general_chair: Konstantinos Psounis 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Konstantinos Psounis
   program_chair: Aditya Akella, Adam Wierman
-
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2017
   link: https://www.sigmetrics.org/sigmetrics2017/
-  deadline: "2016-10-18"
-  abstract_deadline: "2016-10-11"
-  notification_date: "2016-12-30"
-  date: "2017-06-05"
+  deadline: '2016-10-18'
+  abstract_deadline: '2016-10-11'
+  notification_date: '2016-12-30'
+  date: '2017-06-05'
   place: Urbana-Champaign, IL, USA
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Bruce Hajek, Sewoong Oh
   program_chair: Augustin Chaintreau, Leana Golubchik, Zhi-Li Zhang
-
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2017
   link: https://www.sigmetrics.org/sigmetrics2017/
-  deadline: "2017-01-17"
-  abstract_deadline: "2017-01-10"
-  notification_date: "2017-04-01"
-  date: "2017-06-05"
+  deadline: '2017-01-17'
+  abstract_deadline: '2017-01-10'
+  notification_date: '2017-04-01'
+  date: '2017-06-05'
   place: Urbana-Champaign, IL, USA
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Bruce Hajek, Sewoong Oh
   program_chair: Augustin Chaintreau, Leana Golubchik, Zhi-Li Zhang
-
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2016
   link: https://www.sigmetrics.org/sigmetrics2016/
-  deadline: "2015-11-30"
-  abstract_deadline: "2015-11-23"
-  notification_date: "2016-02-20"
-  date: "2016-06-14"
+  deadline: '2015-11-30'
+  abstract_deadline: '2015-11-23'
+  notification_date: '2016-02-20'
+  date: '2016-06-14'
   place: Antibes Juan-les-Pins, France
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Sara Alouf, Alain Jean-Marie
-  program_chair: Nidhi Hegde, Alexandre Proutière, 
-
+  program_chair: Nidhi Hegde, Alexandre Proutière,
+  series_link: https://sigmetrics.org/
 - name: SIGMETRICS
   description: ACM SIGMETRICS / IFIP Performance Conference
   year: 2015
   link: https://www.sigmetrics.org/sigmetrics2015/
-  deadline: "2014-11-24"
-  abstract_deadline: "2014-11-17"
-  notification_date: "2015-02-17"
-  date: "2015-06-15"
+  deadline: '2014-11-24'
+  abstract_deadline: '2014-11-17'
+  notification_date: '2015-02-17'
+  date: '2015-06-15'
   place: Portland, OR, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: Bill Lin, Jun (Jim) Xu, 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Bill Lin, Jun (Jim) Xu,
   program_chair: Sudipta Sengupta, Devavrat Shah
-
-# Operating systems
-
+  series_link: https://sigmetrics.org/
 - name: OSDI
   description: USENIX Symposium on Operating Systems Design and Implementation
   year: 2025
   link: https://www.usenix.org/conference/osdi25
-  deadline: "2024-12-10"
-  abstract_deadline: "2024-12-03"
-  notification_date: "2025-03-25"
-  date: "2025-07-07"
+  deadline: '2024-12-10'
+  abstract_deadline: '2024-12-03'
+  notification_date: '2025-03-25'
+  date: '2025-07-07'
   place: Boston, MA, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Lidong Zhou, Yuanyuan Zhou
-
+  series_link: https://osdi.org/
 - name: OSDI
   description: USENIX Symposium on Operating Systems Design and Implementation
   year: 2024
   link: https://www.usenix.org/conference/osdi24
-  deadline: "2023-12-07"
-  abstract_deadline: "2023-11-30"
-  notification_date: "2024-03-21"
-  date: "2024-07-10"
+  deadline: '2023-12-07'
+  abstract_deadline: '2023-11-30'
+  notification_date: '2024-03-21'
+  date: '2024-07-10'
   place: Santa Clara, CA, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Ada Gavrilovska, Douglas B. Terry
-
+  series_link: https://osdi.org/
 - name: OSDI
   description: USENIX Symposium on Operating Systems Design and Implementation
   year: 2023
   link: https://www.usenix.org/conference/osdi23
-  deadline: "2022-12-13"
-  abstract_deadline: "2022-12-06"
-  notification_date: "2023-03-23"
-  date: "2023-07-10"
+  deadline: '2022-12-13'
+  abstract_deadline: '2022-12-06'
+  notification_date: '2023-03-23'
+  date: '2023-07-10'
   place: Boston, MA, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Roxana Geambasu, Ed Nightingale
-
+  series_link: https://osdi.org/
 - name: OSDI
   description: USENIX Symposium on Operating Systems Design and Implementation
   year: 2022
   link: https://www.usenix.org/conference/osdi22
-  deadline: "2021-12-14"
-  abstract_deadline: "2021-12-07"
-  notification_date: "2022-03-25"
-  date: "2022-07-11"
+  deadline: '2021-12-14'
+  abstract_deadline: '2021-12-07'
+  notification_date: '2022-03-25'
+  date: '2022-07-11'
   place: Carlsbad, CA, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Marcos K. Aguilera, Hakim Weatherspoon
-
+  series_link: https://osdi.org/
 - name: OSDI
   description: USENIX Symposium on Operating Systems Design and Implementation
   year: 2021
   link: https://www.usenix.org/conference/osdi21
-  deadline: "2020-12-10"
-  abstract_deadline: "2020-12-03"
-  notification_date: "2021-03-16"
-  date: "2021-07-14"
+  deadline: '2020-12-10'
+  abstract_deadline: '2020-12-03'
+  notification_date: '2021-03-16'
+  date: '2021-07-14'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Angela Demke Brown, Jay Lorch
-
+  series_link: https://osdi.org/
 - name: OSDI
   description: USENIX Symposium on Operating Systems Design and Implementation
   year: 2020
   link: https://www.usenix.org/conference/osdi20
-  deadline: "2020-05-27"
-  abstract_deadline: "2020-05-20"
-  notification_date: "2020-08-18"
-  date: "2020-11-04"
+  deadline: '2020-05-27'
+  abstract_deadline: '2020-05-20'
+  notification_date: '2020-08-18'
+  date: '2020-11-04'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Jon Howell, Shan Lu
-
+  series_link: https://osdi.org/
 - name: OSDI
   description: USENIX Symposium on Operating Systems Design and Implementation
   year: 2018
   link: https://www.usenix.org/conference/osdi18
-  deadline: "2018-05-03"
-  abstract_deadline: "2018-04-26"
-  notification_date: "2018-07-24"
-  date: "2018-10-08"
+  deadline: '2018-05-03'
+  abstract_deadline: '2018-04-26'
+  notification_date: '2018-07-24'
+  date: '2018-10-08'
   place: Carlsbad, CA, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Andrea Arpaci-Dusseau, Geoff Voelker
-
+  series_link: https://osdi.org/
 - name: OSDI
   description: USENIX Symposium on Operating Systems Design and Implementation
   year: 2016
   link: https://www.usenix.org/conference/osdi16
-  deadline: "2016-05-10"
-  abstract_deadline: "2016-05-03"
-  notification_date: "2016-07-30"
-  date: "2016-11-02"
+  deadline: '2016-05-10'
+  abstract_deadline: '2016-05-03'
+  notification_date: '2016-07-30'
+  date: '2016-11-02'
   place: Savannah, GA, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Kimberly Keeton, Timothy Roscoe
-
+  series_link: https://osdi.org/
 - name: SOSP
   description: ACM Symposium on Operating Systems Principles
   year: 2026
   link: https://sigops.org/s/conferences/sosp/2026/
-  deadline: "2026-04-01"
-  abstract_deadline: "2026-03-26"
-  notification_date: "2026-07-03"
-  date: "2026-09-29"
+  deadline: '2026-04-01'
+  abstract_deadline: '2026-03-26'
+  notification_date: '2026-07-03'
+  date: '2026-09-29'
   place: Prague, Czech Republic
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Pramod Bhatotia, Christof Fetzer
   program_chair: Angela Demke Brown, Shan Lu
-
+  series_link: https://sosp.org/
 - name: SOSP
   description: ACM Symposium on Operating Systems Principles
   year: 2025
   link: https://sigops.org/s/conferences/sosp/2025/
-  deadline: "2025-04-17"
-  abstract_deadline: "2025-04-10"
-  notification_date: "2025-07-15"
-  date: "2025-10-13"
+  deadline: '2025-04-17'
+  abstract_deadline: '2025-04-10'
+  notification_date: '2025-07-15'
+  date: '2025-10-13'
   place: Seoul, Republic of Korea
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Youjip Won, Youngjin Kwon
   program_chair: Rebecca Isaacs, Ding Yuan
-
+  series_link: https://sosp.org/
 - name: SOSP
   description: ACM Symposium on Operating Systems Principles
   year: 2024
   link: https://sigops.org/s/conferences/sosp/2024/
-  deadline: "2024-04-19"
-  abstract_deadline: "2024-04-12"
-  notification_date: "2024-08-05"
-  date: "2024-11-04"
+  deadline: '2024-04-19'
+  abstract_deadline: '2024-04-12'
+  notification_date: '2024-08-05'
+  date: '2024-11-04'
   place: Austin, TX, USA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Emmett Witchel, Christopher J. Rossbach
   program_chair: Andrea Arpaci-Dusseau, Kimberly Keeton
-
+  series_link: https://sosp.org/
 - name: SOSP
   description: ACM Symposium on Operating Systems Principles
   year: 2023
   link: https://sosp2023.mpi-sws.org/
-  deadline: "2023-04-17"
-  abstract_deadline: "2023-04-10"
-  notification_date: "2023-07-16"
-  date: "2023-10-23"
+  deadline: '2023-04-17'
+  abstract_deadline: '2023-04-10'
+  notification_date: '2023-07-16'
+  date: '2023-10-23'
   place: Koblenz, Germany
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Peter Druschel, Antoine Kaufmann, Jonathan Mace
   program_chair: Jason Flinn, Margo Seltzer
-
+  series_link: https://sosp.org/
 - name: SOSP
   description: ACM Symposium on Operating Systems Principles
   year: 2021
   link: https://sosp2021.mpi-sws.org
-  deadline: "2021-05-07"
-  abstract_deadline: "2021-04-30"
-  notification_date: "2021-08-09"
-  date: "2021-10-25"
+  deadline: '2021-05-07'
+  abstract_deadline: '2021-04-30'
+  notification_date: '2021-08-09'
+  date: '2021-10-25'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Vijay Chidambaram, Anthony D. Joseph
   program_chair: Robbert van Renesse, Nickolai Zeldovich
-
+  series_link: https://sosp.org/
 - name: SOSP
   description: ACM Symposium on Operating Systems Principles
   year: 2019
   link: https://www.sigops.org/s/conferences/sosp/2019/program.html
-  deadline: "2019-04-24"
-  abstract_deadline: "2019-04-17"
-  notification_date: "2019-07-22"
-  date: "2019-10-27"
+  deadline: '2019-04-24'
+  abstract_deadline: '2019-04-17'
+  notification_date: '2019-07-22'
+  date: '2019-10-27'
   place: Huntsville, Ontario, Canada
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Tim Brecht, Carey Williamson
   program_chair: Remzi H. Arpaci-Dusseau, Yuanyuan Zhou
-
+  series_link: https://sosp.org/
 - name: SOSP
   description: ACM Symposium on Operating Systems Principles
   year: 2017
   link: https://www.sigops.org/sosp/sosp17/
-  deadline: "2017-04-21"
-  abstract_deadline: "2017-04-14"
-  notification_date: "2017-08-07"
-  date: "2017-10-28"
+  deadline: '2017-04-21'
+  abstract_deadline: '2017-04-14'
+  notification_date: '2017-08-07'
+  date: '2017-10-28'
   place: Shanghai, China
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Haibo Chen, Lidong Zhou
   program_chair: Lorenzo Alvisi, Peter Chen
-
+  series_link: https://sosp.org/
 - name: SOSP
   description: ACM Symposium on Operating Systems Principles
   year: 2015
   link: https://sigops.org/s/conferences/sosp/2015/website/index.html
-  deadline: "2015-03-26"
-  abstract_deadline: "2015-03-19"
-  notification_date: "2015-06-29"
-  date: "2015-10-04"
+  deadline: '2015-03-26'
+  abstract_deadline: '2015-03-19'
+  notification_date: '2015-06-29'
+  date: '2015-10-04'
   place: Monterey, CA, USA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Ethan Miller
   program_chair: Steven Hand
-
+  series_link: https://sosp.org/
 - name: EuroSys
   description: European Conference on Computer Systems
   year: 2026
   link: https://2026.eurosys.org
-  deadline: "2025-05-15"
-  abstract_deadline: "2025-05-08"
-  notification_date: "2025-08-22"
-  date: "2026-03-13"
+  deadline: '2025-05-15'
+  abstract_deadline: '2025-05-08'
+  notification_date: '2025-08-22'
+  date: '2026-03-13'
   place: Edinburgh, Scotland
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Antonio Barbalace, Luo Mai
   program_chair: Roxana Geambasu, Peter Pietzuch
-
+  series_link: https://www.eurosys.org/
 - name: EuroSys
   description: European Conference on Computer Systems
   year: 2026
   link: https://2026.eurosys.org
-  deadline: "2025-09-25"
-  abstract_deadline: "2025-09-18"
-  notification_date: "2026-01-30"
-  rebuttal_date: "2026-01-09"
-  date: "2026-03-13"
+  deadline: '2025-09-25'
+  abstract_deadline: '2025-09-18'
+  notification_date: '2026-01-30'
+  rebuttal_date: '2026-01-09'
+  date: '2026-03-13'
   place: Edinburgh, Scotland
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Antonio Barbalace, Luo Mai
   program_chair: Roxana Geambasu, Peter Pietzuch
-
+  series_link: https://www.eurosys.org/
 - name: EuroSys
   description: European Conference on Computer Systems
   year: 2025
   link: https://2025.eurosys.org
-  deadline: "2024-05-21"
-  abstract_deadline: "2024-05-14"
-  notification_date: "2024-08-21"
-  date: "2025-03-30"
+  deadline: '2024-05-21'
+  abstract_deadline: '2024-05-14'
+  notification_date: '2024-08-21'
+  date: '2025-03-30'
   place: Rotterdam, Netherlands
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Cristiano Giuffrida, Kaitai Liang, Georgios Smaragdakis
-  program_chair: Julia Lawall, Haibo Chen 
-
+  program_chair: Julia Lawall, Haibo Chen
+  series_link: https://www.eurosys.org/
 - name: EuroSys
   description: European Conference on Computer Systems
   year: 2025
   link: https://2025.eurosys.org
-  deadline: "2024-10-22"
-  abstract_deadline: "2024-10-15"
-  notification_date: "2025-01-25"
-  date: "2025-03-30"
+  deadline: '2024-10-22'
+  abstract_deadline: '2024-10-15'
+  notification_date: '2025-01-25'
+  date: '2025-03-30'
   place: Rotterdam, Netherlands
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Cristiano Giuffrida, Kaitai Liang, Georgios Smaragdakis
-  program_chair: Julia Lawall, Haibo Chen 
-
+  program_chair: Julia Lawall, Haibo Chen
+  series_link: https://www.eurosys.org/
 - name: EuroSys
   description: European Conference on Computer Systems
   year: 2024
   link: https://2024.eurosys.org/
-  deadline: "2023-05-24"
-  abstract_deadline: 
-  notification_date: "2023-09-12"
-  date: "2024-04-22"
+  deadline: '2023-05-24'
+  abstract_deadline: null
+  notification_date: '2023-09-12'
+  date: '2024-04-22'
   place: Athens, Greece
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Vana Kalogeraki, Spyros Voulgaris
   program_chair: Bianca Schroeder, Mark Silberstein
-
+  series_link: https://www.eurosys.org/
 - name: EuroSys
   description: European Conference on Computer Systems
   year: 2024
   link: https://2024.eurosys.org/
-  deadline: "2023-10-19"
-  abstract_deadline: 
-  notification_date: "2024-03-07"
-  date: "2024-04-22"
+  deadline: '2023-10-19'
+  abstract_deadline: null
+  notification_date: '2024-03-07'
+  date: '2024-04-22'
   place: Athens, Greece
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Vana Kalogeraki, Spyros Voulgaris
   program_chair: Bianca Schroeder, Mark Silberstein
-
+  series_link: https://www.eurosys.org/
 - name: EuroSys
   description: European Conference on Computer Systems
   year: 2023
   link: https://2023.eurosys.org/
-  deadline: "2022-05-18"
-  abstract_deadline: "2022-05-11"
-  notification_date: "2022-08-10"
-  date: "2023-05-08"
+  deadline: '2022-05-18'
+  abstract_deadline: '2022-05-11'
+  notification_date: '2022-08-10'
+  date: '2023-05-08'
   place: Rome, Italy
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Giuseppe Antonio Di Luna, Leonardo Querzoni
   program_chair: Alexandra (Sasha) Fedorova, Dushyanth Narayanan
-
+  series_link: https://www.eurosys.org/
 - name: EuroSys
   description: European Conference on Computer Systems
   year: 2023
   link: https://2023.eurosys.org/
-  deadline: "2022-10-19"
-  abstract_deadline: "2022-10-12"
-  notification_date: "2023-01-18"
-  date: "2023-05-08"
+  deadline: '2022-10-19'
+  abstract_deadline: '2022-10-12'
+  notification_date: '2023-01-18'
+  date: '2023-05-08'
   place: Rome, Italy
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Giuseppe Antonio Di Luna, Leonardo Querzoni
   program_chair: Alexandra (Sasha) Fedorova, Dushyanth Narayanan
-
+  series_link: https://www.eurosys.org/
 - name: EuroSys
   description: European Conference on Computer Systems
   year: 2022
   link: https://2022.eurosys.org/
-  deadline: "2021-10-09"
-  abstract_deadline: "2021-10-01"
-  notification_date: "2022-01-20"
-  date: "2022-04-05"
+  deadline: '2021-10-09'
+  abstract_deadline: '2021-10-01'
+  notification_date: '2022-01-20'
+  date: '2022-04-05'
   place: Rennes, France
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: David Bromberg
-  program_chair: 
-
+  program_chair: null
+  series_link: https://www.eurosys.org/
 - name: EuroSys
   description: European Conference on Computer Systems
   year: 2021
   link: https://2021.eurosys.org/
-  deadline: "2020-10-09"
-  abstract_deadline: "2020-10-01"
-  notification_date: "2021-01-20"
-  date: "2021-04-26"
+  deadline: '2020-10-09'
+  abstract_deadline: '2020-10-01'
+  notification_date: '2021-01-20'
+  date: '2021-04-26'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Antonio Barbalace, Pramod Bhatotia
   program_chair: Lorenzo Alvisi, Cristian Cadar
-
+  series_link: https://www.eurosys.org/
 - name: EuroSys
   description: European Conference on Computer Systems
   year: 2020
   link: https://2020.eurosys.org/
-  deadline: "2019-11-04"
-  abstract_deadline: 
-  notification_date: "2020-02-15"
-  date: "2020-04-27"
+  deadline: '2019-11-04'
+  abstract_deadline: null
+  notification_date: '2020-02-15'
+  date: '2020-04-27'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Angelos Bilas, Kostas Magoutis, Evangelos Markatos
   program_chair: Dejan Kostic, Margo Seltzer
-
+  series_link: https://www.eurosys.org/
 - name: EuroSys
   description: European Conference on Computer Systems
   year: 2019
   link: https://2019.eurosys.org
-  deadline: "2018-10-01"
-  abstract_deadline: "2018-09-24"
-  notification_date: "2018-12-21"
-  date: "2019-03-25"
+  deadline: '2018-10-01'
+  abstract_deadline: '2018-09-24'
+  notification_date: '2018-12-21'
+  date: '2019-03-25'
   place: Dresden, Germany
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Christof Fetzer
   program_chair: George Candea, Robbert van Renesse
-
+  series_link: https://www.eurosys.org/
 - name: EuroSys
   description: European Conference on Computer Systems
   year: 2018
   link: https://2018.eurosys.org
-  deadline: "2017-10-27"
-  abstract_deadline: "2017-10-20"
-  notification_date: "2018-01-22"
-  date: "2018-04-23"
+  deadline: '2017-10-27'
+  abstract_deadline: '2017-10-20'
+  notification_date: '2018-01-22'
+  date: '2018-04-23'
   place: Porto, Portugal
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Rui Oliveira
   program_chair: Pascal Felber, Y. Charlie Hu
-
+  series_link: https://www.eurosys.org/
 - name: EuroSys
   description: European Conference on Computer Systems
   year: 2017
   link: https://eurosys2017.github.io
-  deadline: "2016-10-21"
-  abstract_deadline: "2016-10-14"
-  notification_date: "2017-01-23"
-  date: "2017-04-23"
+  deadline: '2016-10-21'
+  abstract_deadline: '2016-10-14'
+  notification_date: '2017-01-23'
+  date: '2017-04-23'
   place: Belgrade, Serbia
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Marko Vukolić
   program_chair: Gustavo Alonso, Ricardo Bianchini
-
+  series_link: https://www.eurosys.org/
 - name: EuroSys
   description: European Conference on Computer Systems
   year: 2016
   link: http://eurosys16.doc.ic.ac.uk
-  deadline: "2015-10-23"
-  abstract_deadline: "2015-10-16"
-  notification_date: "2016-01-29"
-  date: "2016-04-18"
+  deadline: '2015-10-23'
+  abstract_deadline: '2015-10-16'
+  notification_date: '2016-01-29'
+  date: '2016-04-18'
   place: London, UK
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Cristian Cadar, Peter Pietzuch
   program_chair: Kimberly Keeton, Rodrigo Rodrigues
-
+  series_link: https://www.eurosys.org/
 - name: EuroSys
   description: European Conference on Computer Systems
   year: 2015
   link: https://eurosys2015.labri.fr
-  deadline: "2014-10-10"
-  abstract_deadline: "2014-10-03"
-  notification_date: "2015-01-23"
-  date: "2015-04-21"
+  deadline: '2014-10-10'
+  abstract_deadline: '2014-10-03'
+  notification_date: '2015-01-23'
+  date: '2015-04-21'
   place: Bordeaux, France
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Laurent Réveillère
   program_chair: Tim Harris, Maurice Herlihy
-
+  series_link: https://www.eurosys.org/
 - name: FAST
   description: USENIX Conference on File and Storage Technologies
   year: 2025
   link: https://www.usenix.org/conference/fast25
-  deadline: "2024-09-17"
-  abstract_deadline: 
-  notification_date: "2024-12-06"
-  date: "2025-02-25"
+  deadline: '2024-09-17'
+  abstract_deadline: null
+  notification_date: '2024-12-06'
+  date: '2025-02-25'
   place: Santa Clara, CA, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Haryadi Gunawi, Vasily Tarasov
-
+  series_link: https://fast.org/
 - name: FAST
   description: USENIX Conference on File and Storage Technologies
   year: 2024
   link: https://www.usenix.org/conference/fast24
-  deadline: "2023-09-21"
-  abstract_deadline: 
-  notification_date: "2023-12-08"
-  date: "2024-02-27"
+  deadline: '2023-09-21'
+  abstract_deadline: null
+  notification_date: '2023-12-08'
+  date: '2024-02-27'
   place: Santa Clara, CA, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Xiaosong Ma, Youjip Won
-
+  series_link: https://fast.org/
 - name: FAST
   description: USENIX Conference on File and Storage Technologies
   year: 2023
   link: https://www.usenix.org/conference/fast23
-  deadline: "2022-09-22"
-  abstract_deadline: 
-  notification_date: "2022-12-09"
-  date: "2023-02-21"
+  deadline: '2022-09-22'
+  abstract_deadline: null
+  notification_date: '2022-12-09'
+  date: '2023-02-21'
   place: Santa Clara, CA, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Ashvin Goel, Dalit Naor
-
+  series_link: https://fast.org/
 - name: FAST
   description: USENIX Conference on File and Storage Technologies
   year: 2022
   link: https://www.usenix.org/conference/fast22
-  deadline: "2021-09-23"
-  abstract_deadline: 
-  notification_date: "2021-12-10"
-  date: "2022-02-22"
+  deadline: '2021-09-23'
+  abstract_deadline: null
+  notification_date: '2021-12-10'
+  date: '2022-02-22'
   place: Santa Clara, CA, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Dean Hildebrand, Don Porter
-
+  series_link: https://fast.org/
 - name: FAST
   description: USENIX Conference on File and Storage Technologies
   year: 2021
   link: https://www.usenix.org/conference/fast21
-  deadline: "2020-09-24"
-  abstract_deadline: 
-  notification_date: "2020-12-11"
-  date: "2021-02-23"
+  deadline: '2020-09-24'
+  abstract_deadline: null
+  notification_date: '2020-12-11'
+  date: '2021-02-23'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Marcos K. Aguilera, Gala Yadgar
-
+  series_link: https://fast.org/
 - name: FAST
   description: USENIX Conference on File and Storage Technologies
   year: 2020
   link: https://www.usenix.org/conference/fast20
-  deadline: "2019-09-26"
-  abstract_deadline: 
-  notification_date: "2019-12-11"
-  date: "2020-02-24"
+  deadline: '2019-09-26'
+  abstract_deadline: null
+  notification_date: '2019-12-11'
+  date: '2020-02-24'
   place: Santa Clara, CA, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Sam H. Noh, Brent Welch
-
+  series_link: https://fast.org/
 - name: FAST
   description: USENIX Conference on File and Storage Technologies
   year: 2019
   link: https://www.usenix.org/conference/fast19
-  deadline: "2018-09-26"
-  abstract_deadline: 
-  notification_date: "2018-12-11"
-  date: "2019-02-25"
+  deadline: '2018-09-26'
+  abstract_deadline: null
+  notification_date: '2018-12-11'
+  date: '2019-02-25'
   place: Boston, MA, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Arif Merchant, Hakim Weatherspoon
-
+  series_link: https://fast.org/
 - name: FAST
   description: USENIX Conference on File and Storage Technologies
   year: 2018
   link: https://www.usenix.org/conference/fast18
-  deadline: "2017-09-28"
-  abstract_deadline: 
-  notification_date: "2017-12-11"
-  date: "2018-02-12"
+  deadline: '2017-09-28'
+  abstract_deadline: null
+  notification_date: '2017-12-11'
+  date: '2018-02-12'
   place: Oakland, CA, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Nitin Agrawal, Raju Rangaswami
-
+  series_link: https://fast.org/
 - name: USENIX ATC
   description: USENIX Annual Technical Conference
   year: 2025
   link: https://www.usenix.org/conference/atc25
-  deadline: "2025-01-14"
-  abstract_deadline: "2025-01-07"
-  notification_date: "20205-04-25"
-  date: "2025-07-07"
+  deadline: '2025-01-14'
+  abstract_deadline: '2025-01-07'
+  notification_date: 20205-04-25
+  date: '2025-07-07'
   place: Boston, MA, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Deniz Altınbüken, Ryan Stutsman
-
 - name: USENIX ATC
   description: USENIX Annual Technical Conference
   year: 2024
   link: https://www.usenix.org/conference/atc24
-  deadline: "2024-01-16"
-  abstract_deadline: "2024-01-09"
-  notification_date: "2024-04-30"
-  date: "2024-07-10"
+  deadline: '2024-01-16'
+  abstract_deadline: '2024-01-09'
+  notification_date: '2024-04-30'
+  date: '2024-07-10'
   place: Santa Clara, CA, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Saurabh Bagchi, Yiying Zhang
-
 - name: USENIX ATC
   description: USENIX Annual Technical Conference
   year: 2023
   link: https://www.usenix.org/conference/atc23
-  deadline: "2023-01-12"
-  abstract_deadline: "2023-01-05"
-  notification_date: "2023-04-28"
-  date: "2023-07-10"
+  deadline: '2023-01-12'
+  abstract_deadline: '2023-01-05'
+  notification_date: '2023-04-28'
+  date: '2023-07-10'
   place: Boston, MA, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Julia Lawall, Dan Williams
-
 - name: USENIX ATC
   description: USENIX Annual Technical Conference
   year: 2022
   link: https://www.usenix.org/conference/atc22
-  deadline: "2022-01-13"
-  abstract_deadline: "2022-01-06"
-  notification_date: "2022-04-29"
-  date: "2022-07-11"
+  deadline: '2022-01-13'
+  abstract_deadline: '2022-01-06'
+  notification_date: '2022-04-29'
+  date: '2022-07-11'
   place: Carlsbad, CA, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Jiri Schindler, Noa Zilberman
-
 - name: USENIX ATC
   description: USENIX Annual Technical Conference
   year: 2021
   link: https://www.usenix.org/conference/atc21
-  deadline: "2021-01-12"
-  abstract_deadline: 
-  notification_date: "2021-04-26"
-  date: "2021-07-14"
+  deadline: '2021-01-12'
+  abstract_deadline: null
+  notification_date: '2021-04-26'
+  date: '2021-07-14'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Irina Calciu, Geoff Kuenning
-
 - name: USENIX ATC
   description: USENIX Annual Technical Conference
   year: 2020
   link: https://www.usenix.org/conference/atc20
-  deadline: "2020-01-15"
-  abstract_deadline: 
-  notification_date: "2020-04-24"
-  date: "2020-07-15"
+  deadline: '2020-01-15'
+  abstract_deadline: null
+  notification_date: '2020-04-24'
+  date: '2020-07-15'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Ada Gavrilovska, Erez Zadok
-
 - name: USENIX ATC
   description: USENIX Annual Technical Conference
   year: 2019
   link: https://www.usenix.org/conference/atc19
-  deadline: "2019-01-10"
-  abstract_deadline: 
-  notification_date: "2019-04-16"
-  date: "2019-07-10"
+  deadline: '2019-01-10'
+  abstract_deadline: null
+  notification_date: '2019-04-16'
+  date: '2019-07-10'
   place: Renton, WA, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Dahlia Malkhi, Dan Tsafrir
-
 - name: USENIX ATC
   description: USENIX Annual Technical Conference
   year: 2018
   link: https://www.usenix.org/conference/atc18
-  deadline: "2018-02-06"
-  abstract_deadline: "2018-01-30"
-  notification_date: "2018-04-18"
-  date: "2018-07-11"
+  deadline: '2018-02-06'
+  abstract_deadline: '2018-01-30'
+  notification_date: '2018-04-18'
+  date: '2018-07-11'
   place: Boston, MA, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Haryadi Gunawi, Benjamin Reed
-
 - name: USENIX ATC
   description: USENIX Annual Technical Conference
   year: 2017
   link: https://www.usenix.org/conference/atc17
-  deadline: "2017-02-07"
-  abstract_deadline: 
-  notification_date: "2017-04-21"
-  date: "2017-07-12"
+  deadline: '2017-02-07'
+  abstract_deadline: null
+  notification_date: '2017-04-21'
+  date: '2017-07-12'
   place: Santa Clara, CA, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Dilma Da Silva, Bryan Ford
-
 - name: USENIX ATC
   description: USENIX Annual Technical Conference
   year: 2016
   link: https://www.usenix.org/conference/atc16
-  deadline: "2016-02-01"
-  abstract_deadline: 
-  notification_date: "2016-04-15"
-  date: "2016-06-22"
+  deadline: '2016-02-01'
+  abstract_deadline: null
+  notification_date: '2016-04-15'
+  date: '2016-06-22'
   place: Denver, CO, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Ajay Gulati, Hakim Weatherspoon
-
 - name: USENIX ATC
   description: USENIX Annual Technical Conference
   year: 2015
   link: https://www.usenix.org/conference/atc15
-  deadline: "2015-02-03"
-  abstract_deadline: "2015-01-27"
-  notification_date: "2015-04-16"
-  date: "2015-07-08"
+  deadline: '2015-02-03'
+  abstract_deadline: '2015-01-27'
+  notification_date: '2015-04-16'
+  date: '2015-07-08'
   place: Santa Clara, CA, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Shan Lu, Erik Riedel
-        
-
-## Software Engineering
-
 - name: ASE
   description: Automated Software Engineering
   year: 2025
   link: https://conf.researchr.org/home/ase-2025
-  deadline: "2025-05-30"
-  notification_date: "2025-08-14"
-  note: 
-  date: "2025-11-16"
+  deadline: '2025-05-30'
+  notification_date: '2025-08-14'
+  note: null
+  date: '2025-11-16'
   place: Seoul, Korea
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Shin Yoo
   program_chair: Marchel Bohme, Lingming Zhang
-
 - name: ASE
   description: Automated Software Engineering
   year: 2024
   link: https://conf.researchr.org/home/ase-2024
-  deadline: "2024-06-07"
-  abstract_deadline: "2024-05-31"
-  notification_date: "2024-07-22"
-  note: 
-  date: "2024-10-27"
+  deadline: '2024-06-07'
+  abstract_deadline: '2024-05-31'
+  notification_date: '2024-07-22'
+  note: null
+  date: '2024-10-27'
   place: Sacramento, CA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Vladimir Filkov
   program_chair: Baishakhi Ray, Minghui Zhou
-
 - name: ASE
   description: Automated Software Engineering
   year: 2023
   link: https://conf.researchr.org/home/ase-2023
-  deadline: "2023-05-05"
-  abstract_deadline: "2023-04-28"
-  notification_date: "2023-07-17"
-  note: 
-  date: "2023-09-11"
+  deadline: '2023-05-05'
+  abstract_deadline: '2023-04-28'
+  notification_date: '2023-07-17'
+  note: null
+  date: '2023-09-11'
   place: Luxembourg
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Tegawendé F. Bissyandé, Jacques Klein
   program_chair: :Christian Bird, Federica Sarro
-
 - name: ASE
   description: Automated Software Engineering
   year: 2022
   link: https://conf.researchr.org/home/ase-2022
-  deadline: "2022-05-06"
-  abstract_deadline: "2022-04-29"
-  notification_date: "2022-07-20"
-  note: 
-  date: "2022-10-10"
+  deadline: '2022-05-06'
+  abstract_deadline: '2022-04-29'
+  notification_date: '2022-07-20'
+  note: null
+  date: '2022-10-10'
   place: Oakland Center, MI
-  acceptance_rate: 
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Marouane Kessentini
   program_chair: Julia Rubin, Shahar Maoz
-
 - name: ASE
   description: Automated Software Engineering
   year: 2021
   link: https://conf.researchr.org/home/ase-2021
-  deadline: "2021-04-23"
-  abstract_deadline: "2021-04-16"
-  notification_date: "2021-07-07"
+  deadline: '2021-04-23'
+  abstract_deadline: '2021-04-16'
+  notification_date: '2021-07-07'
   note: Virtual conference
-  date: "2021-11-14"
+  date: '2021-11-14'
   place: Melbourne, Australia
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: John Grundy
   program_chair: Dan Hao, Denys Poshyvanyk
-
 - name: ASE
   description: Automated Software Engineering
   year: 2020
   link: https://conf.researchr.org/home/ase-2020
-  deadline: "2020-05-08"
-  abstract_deadline: "2020-05-01"
-  notification_date: "2020-07-31"
+  deadline: '2020-05-08'
+  abstract_deadline: '2020-05-01'
+  notification_date: '2020-07-31'
   note: Virtual conference
-  date: "2020-09-21"
+  date: '2020-09-21'
   place: Melbourne, Australia
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: John Grundy
-  program_chair: Claire Le Goues, David Lo 
-
+  program_chair: Claire Le Goues, David Lo
 - name: ASE
   description: Automated Software Engineering
   year: 2019
   link: https://2019.ase-conferences.org/
-  deadline: "2019-05-13"
-  abstract_deadline: "2019-05-06"
-  notification_date: "2019-08-05"
-  note: 
-  date: "2019-11-10"
+  deadline: '2019-05-13'
+  abstract_deadline: '2019-05-06'
+  notification_date: '2019-08-05'
+  note: null
+  date: '2019-11-10'
   place: San Diego, CA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Thomas Zimmermann
-  program_chair: Julia Lawall, Darko Marinov 
-
+  program_chair: Julia Lawall, Darko Marinov
 - name: ASE
   description: Automated Software Engineering
   year: 2018
   link: http://ase2018.com
-  deadline: "2018-04-26"
-  abstract_deadline: "2018-04-19"
-  notification_date: "2018-07-03"
-  note: 
-  date: "2018-09-03"
+  deadline: '2018-04-26'
+  abstract_deadline: '2018-04-19'
+  notification_date: '2018-07-03'
+  note: null
+  date: '2018-09-03'
   place: Montpellier, France
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Marianne Huchard
   program_chair: Christian Kästner, Gordon Fraser
-
 - name: ASE
   description: Automated Software Engineering
   year: 2017
   link: https://www.se.cs.uni-saarland.de/conferences/ASE/ase2017/index.html
-  deadline: "2017-05-12"
-  abstract_deadline: "2017-05-05"
-  notification_date: "2017-07-21"
-  note: 
-  date: "2017-10-30"
+  deadline: '2017-05-12'
+  abstract_deadline: '2017-05-05'
+  notification_date: '2017-07-21'
+  note: null
+  date: '2017-10-30'
   place: Urbana-Champaign, IL
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Grigore Rosu
   program_chair: Massimiliano Di Penta, Tien N. Nguyen
-
 - name: FSE
   description: Foundations of Software Engineering
   year: 2026
   link: https://conf.researchr.org/home/fse-2026
-  deadline: "2025-09-11"
-  abstract_deadline: "2025-09-04"
-  notification_date: "2025-12-22"
-  date: "2026-07-05"
+  deadline: '2025-09-11'
+  abstract_deadline: '2025-09-04'
+  notification_date: '2025-12-22'
+  date: '2026-07-05'
   place: Montreal, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Foutse Khomh, Shin Hwei Tan
   program_chair: Julia Lawall, Christoph Treude
-
 - name: FSE
   description: Foundations of Software Engineering
   year: 2025
   link: https://conf.researchr.org/home/fse-2025
-  deadline: "2024-09-12"
-  notification_date: "2025-01-14"
-  note: "Paper Registration: 2024-09-04"
-  date: "2025-06-23"
+  deadline: '2024-09-12'
+  notification_date: '2025-01-14'
+  note: 'Paper Registration: 2024-09-04'
+  date: '2025-06-23'
   place: Trondheim, Norway
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jingyue Li
   program_chair: Denys Poshyvanyk, Dongmei Zhang
-
 - name: FSE
   description: Foundations of Software Engineering
   year: 2024
   link: https://conf.researchr.org/home/fse-2024
-  deadline: "2023-09-28"
-  notification_date: "2024-01-23"
-  note: "Paper Registration: 2023-09-21"
-  date: "2024-07-15"
+  deadline: '2023-09-28'
+  notification_date: '2024-01-23'
+  note: 'Paper Registration: 2023-09-21'
+  date: '2024-07-15'
   place: Porto de Galinhas, Brazil
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Marcelo d'Amorim
   program_chair: David Lo, Lin Tan
-
 - name: FSE
   description: Foundations of Software Engineering
   year: 2023
   link: https://conf.researchr.org/home/fse-2023
-  deadline: "2023-02-02"
-  abstract_deadline: "2023-01-26"
-  notification_date: "2023-05-04"
-  note: 
-  date: "2023-12-03"
+  deadline: '2023-02-02'
+  abstract_deadline: '2023-01-26'
+  notification_date: '2023-05-04'
+  note: null
+  date: '2023-12-03'
   place: San Francisco, CA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Satish Chandra
   program_chair: Kelly Blincoe, Paolo Tonella
-
 - name: FSE
   description: Foundations of Software Engineering
   year: 2022
   link: https://conf.researchr.org/home/fse-2022
-  deadline: "2022-03-17"
-  abstract_deadline: "2022-03-10"
-  notification_date: "2022-06-14"
-  note: 
-  date: "2022-11-14"
+  deadline: '2022-03-17'
+  abstract_deadline: '2022-03-10'
+  notification_date: '2022-06-14'
+  note: null
+  date: '2022-11-14'
   place: Singapore
-  acceptance_rate:
-  num_submission:  
+  acceptance_rate: null
+  num_submission: null
   general_chair: Abhik Roychoudhury
   program_chair: Cristian Cadar, Miryung Kim
-
 - name: FSE
   description: Foundations of Software Engineering
   year: 2021
   link: https://2021.esec-fse.org/
-  deadline: "2021-02-25"
-  notification_date: "2021-05-21"
+  deadline: '2021-02-25'
+  notification_date: '2021-05-21'
   note: Virtual conference
-  date: "2021-08-19"
+  date: '2021-08-19'
   place: Virtual
   acceptance_rate: 24.5%
   num_submission: 407
   general_chair: Diomidis Spinellis, Georgios Gousios
   program_chair: Marsha Chechik, Massimiliano Di Penta
-
 - name: FSE
   description: Foundations of Software Engineering
   year: 2020
   link: https://2020.esec-fse.org/
-  deadline: "2020-03-05"
-  notification_date: "2020-05-21"
+  deadline: '2020-03-05'
+  notification_date: '2020-05-21'
   note: Virtual conference
-  date: "2020-11-06"
+  date: '2020-11-06'
   place: Virtual
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Prem Devanbu
   program_chair: Myra Cohen, Thomas Zimmermann
-
 - name: FSE
   description: Foundations of Software Engineering
   year: 2019
   link: https://esec-fse19.ut.ee
-  deadline: "2019-02-20"
-  notification_date: "2019-05-27"
-  note:
-  date: "2019-08-26"
+  deadline: '2019-02-20'
+  notification_date: '2019-05-27'
+  note: null
+  date: '2019-08-26'
   place: Tallinn, Estonia
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Marlon Dumas, Dietmar Pfahl
   program_chair: Sven Apel, Alessandra Russo
-
 - name: FSE
   description: Foundations of Software Engineering
   year: 2018
   link: https://conf.researchr.org/home/fse-2018
-  deadline: "2018-03-09"
-  notification_date: "2018-06-11"
-  note:
-  date: "2018-11-04"
+  deadline: '2018-03-09'
+  notification_date: '2018-06-11'
+  note: null
+  date: '2018-11-04'
   place: Lake Buena Vista, FL
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Gary T. leavens
   program_chair: Corina S. Păsăreanu, Alessandro Garcia
-
 - name: FSE
   description: Foundations of Software Engineering
   year: 2017
   link: http://esec-fse17.uni-paderborn.de
-  deadline: "2017-02-27"
-  notification_date: "2017-06-02"
-  note:
-  date: "2017-09-04"
+  deadline: '2017-02-27'
+  notification_date: '2017-06-02'
+  note: null
+  date: '2017-09-04'
   place: Paderborn, Germany
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Eric Bodden, Wilhelm Schäfer
   program_chair: Arie van Deursen, Andrea Zisman
-
 - name: FSE
   description: Foundations of Software Engineering
   year: 2016
   link: https://conf.researchr.org/home/fse-2016
-  deadline: "2016-03-11"
-  note:
-  date: "2016-11-13"
+  deadline: '2016-03-11'
+  note: null
+  date: '2016-11-13'
   place: Seattle, WA
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
 - name: ICSE
   description: International Conference on Software Engineering
   year: 2026
   link: https://conf.researchr.org/home/icse-2026
-  deadline: "2025-03-14"
-  abstract_deadline: "2025-03-07"
-  notification_date: "2025-07-20"
-  date: "2026-04-12"
+  deadline: '2025-03-14'
+  abstract_deadline: '2025-03-07'
+  notification_date: '2025-07-20'
+  date: '2026-04-12'
   place: Rio De Janeiro, Brazil
   note: Cycle 1/2
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Marcos Kalinowski, Rafael Prikladnicki
   program_chair: Mira Mezini, Thomas Zimmermann
-
+  series_link: https://icse.org/
 - name: ICSE
   description: International Conference on Software Engineering
   year: 2026
   link: https://conf.researchr.org/home/icse-2026
-  abstract_deadline: "2025-07-11"
-  deadline: "2025-07-18"
-  notification_date: "2025-10-17"
-  date: "2026-04-12"
+  abstract_deadline: '2025-07-11'
+  deadline: '2025-07-18'
+  notification_date: '2025-10-17'
+  date: '2026-04-12'
   place: Rio De Janeiro, Brazil
   note: Cycle 2/2
   general_chair: Marcos Kalinowski, Rafael Prikladnicki
   program_chair: Mira Mezini, Thomas Zimmermann
-
+  series_link: https://icse.org/
 - name: ICSE
   description: International Conference on Software Engineering
   year: 2025
   link: https://conf.researchr.org/home/icse-2025
-  deadline: "2024-03-22"
-  abstract_deadline: "2024-03-15"
-  notification_date: "2024-07-05"
+  deadline: '2024-03-22'
+  abstract_deadline: '2024-03-15'
+  notification_date: '2024-07-05'
   note: Cycle 1/2
-  date: "2025-04-27"
+  date: '2025-04-27'
   place: Ontario, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Lionel Briand, Timothy Lethbridge
   program_chair: Thomas Zimmermann
-
+  series_link: https://icse.org/
 - name: ICSE
   description: International Conference on Software Engineering
   year: 2025
   link: https://conf.researchr.org/home/icse-2025
-  deadline: "2024-08-02"
-  abstract_deadline: "2024-07-26"
-  notification_date: "2024-11-01"
+  deadline: '2024-08-02'
+  abstract_deadline: '2024-07-26'
+  notification_date: '2024-11-01'
   note: Cycle 2/2
-  date: "2025-04-27"
+  date: '2025-04-27'
   place: Ontario, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Lionel Briand, Timothy Lethbridge
   program_chair: Corina S. Păsăreanu, David Lo
-
+  series_link: https://icse.org/
 - name: ICSE
   description: International Conference on Software Engineering
   year: 2024
   link: https://conf.researchr.org/home/icse-2024
-  deadline: "2023-03-29"
-  notification_date: "2023-06-02"
-  date: "2024-04-14"
+  deadline: '2023-03-29'
+  notification_date: '2023-06-02'
+  date: '2024-04-14'
   place: Lisbon, Portugal
   note: Cycle 1/2
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Rui Abreu, Ana Paiva
   program_chair: Margaret-Anne Storey, Abhik Roychoudhury
-
-
+  series_link: https://icse.org/
 - name: ICSE
   description: International Conference on Software Engineering
   year: 2024
   link: https://conf.researchr.org/home/icse-2024
-  deadline: "2023-08-01"
-  notification_date: "2023-10-10"
-  date: "2024-04-14"
+  deadline: '2023-08-01'
+  notification_date: '2023-10-10'
+  date: '2024-04-14'
   place: Lisbon, Portugal
   note: Cycle 2/2
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Rui Abreu, Ana Paiva
   program_chair: Margaret-Anne Storey, Abhik Roychoudhury
-
+  series_link: https://icse.org/
 - name: ICSE
   description: International Conference on Software Engineering
   year: 2023
   link: https://conf.researchr.org/home/icse-2023
-  deadline: "2022-09-01"
-  notification_date: "2022-12-09"
-  note:
-  date: "2023-05-14"
+  deadline: '2022-09-01'
+  notification_date: '2022-12-09'
+  note: null
+  date: '2023-05-14'
   place: Melbourne, Australia
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: John Grundy
   program_chair: Lori Pollock, Massimiliano Di Penta
-
+  series_link: https://icse.org/
 - name: ICSE
   description: International Conference on Software Engineering
   year: 2022
   link: https://conf.researchr.org/home/icse-2022
-  deadline: "2021-09-03"
-  abstract_deadline: "2021-08-27"
-  notification_date: "2021-12-03"
-  note:
-  date: "2022-05-22"
+  deadline: '2021-09-03'
+  abstract_deadline: '2021-08-27'
+  notification_date: '2021-12-03'
+  note: null
+  date: '2022-05-22'
   place: Pittsburgh, PA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Matthew B. Dwyer
   program_chair: Daniela Damian, Andreas Zeller
-
+  series_link: https://icse.org/
 - name: ICSE
   description: International Conference on Software Engineering
   year: 2021
   link: https://conf.researchr.org/home/icse-2021
-  deadline: "2020-08-28"
-  notification_date: "2020-12-17"
+  deadline: '2020-08-28'
+  notification_date: '2020-12-17'
   note: Virtual conference (originally planned for Madrid, Spain)
-  date: "2021-05-25"
+  date: '2021-05-25'
   place: Online
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Natalia Juristo
   program_chair: Arie van Deursen, Tao Xie
-
+  series_link: https://icse.org/
 - name: ICSE
   description: International Conference on Software Engineering
   year: 2020
   link: https://conf.researchr.org/home/icse-2020
-  deadline: "2019-08-23"
-  notification_date: "2019-12-09"
+  deadline: '2019-08-23'
+  notification_date: '2019-12-09'
   note: Virtual conference (originally planned for Seoul, South Korea)
-  date: "2020-06-27"
+  date: '2020-06-27'
   place: Online
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Gregg Rothermel, Doo-Hwan Bae
   program_chair: Jane Cleland-Huang, Darko Marinov
-
+  series_link: https://icse.org/
 - name: ICSE
   description: International Conference on Software Engineering
   year: 2019
   link: https://conf.researchr.org/home/icse-2019
-  deadline: "2018-08-24"
-  notification_date: "2018-12-12"
-  note:
-  date: "2019-05-25"
+  deadline: '2018-08-24'
+  notification_date: '2018-12-12'
+  note: null
+  date: '2019-05-25'
   place: Montreal, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Joanne M. Atlee
   program_chair: Tevfik Bultan, John Whittle
-
+  series_link: https://icse.org/
 - name: ICSE
   description: International Conference on Software Engineering
   year: 2018
   link: https://conf.researchr.org/home/icse-2018
-  deadline: "2017-08-25"
-  notification_date: "2017-12-15"
-  note:
-  date: "2018-05-27"
+  deadline: '2017-08-25'
+  notification_date: '2017-12-15'
+  note: null
+  date: '2018-05-27'
   place: Gothenburg, Sweden
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Ivica Crnkovic
   program_chair: Marsha Chechik, Mark Harman
-
+  series_link: https://icse.org/
 - name: ICSE
   description: International Conference on Software Engineering
   year: 2017
   link: https://icse2017.gatech.edu
-  deadline: "2016-08-26"
-  notification_date: "2016-12-12"
-  note:
-  date: "2017-05-20"
+  deadline: '2016-08-26'
+  notification_date: '2016-12-12'
+  note: null
+  date: '2017-05-20'
   place: Buenos Aires, Argentina
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Sebastian Uchitel
   program_chair: Alessandro Orso, Martin Robillard
-
+  series_link: https://icse.org/
 - name: ICSE
   description: International Conference on Software Engineering
   year: 2016
   link: https://2016.icse.cs.txstate.edu
-  deadline: "2015-08-28"
-  notification_date: "2015-12-15"
-  note:
-  date: "2016-05-14"
+  deadline: '2015-08-28'
+  notification_date: '2015-12-15'
+  note: null
+  date: '2016-05-14'
   place: Austin, TX
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Laura Dillon
   program_chair: Willem Visser, Laurie Williams
-
-
+  series_link: https://icse.org/
 - name: ISSTA
   description: International Symposium on Software Testing and Analysis
   year: 2026
   link: https://conf.researchr.org/home/issta-2026
-  deadline: "2026-01-29"
-  rebuttal_date: "2026-03-19"
-  notification_date: "2026-04-09"
-  note: 
-  date: "2026-10-03"
+  deadline: '2026-01-29'
+  rebuttal_date: '2026-03-19'
+  notification_date: '2026-04-09'
+  note: null
+  date: '2026-10-03'
   place: Oakland, CA
-  acceptance_rate:
-  num_submission:
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://www.issta.org/
 - name: ISSTA
   description: International Symposium on Software Testing and Analysis
   year: 2025
   link: https://conf.researchr.org/home/issta-2025
-  deadline: "2024-10-31"
-  notification_date: "2024-12-19"
-  note: 
-  date: "2025-06-25"
+  deadline: '2024-10-31'
+  notification_date: '2024-12-19'
+  note: null
+  date: '2025-06-25'
   place: Oslo, Norway
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Mike Papadakis
   program_chair: Myra Cohen, Paolo Tonella
-
+  series_link: https://www.issta.org/
 - name: ISSTA
   description: International Symposium on Software Testing and Analysis
   year: 2024
   link: https://conf.researchr.org/home/issta-2024
-  deadline: "2023-12-15"
-  notification_date: "2024-03-02"
-  date: "2024-09-16"
+  deadline: '2023-12-15'
+  notification_date: '2024-03-02'
+  date: '2024-09-16'
   place: Vienna, Austria
   note: Cycle 1/2
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Maria Christakis
   program_chair: Michael Pradel
-
+  series_link: https://www.issta.org/
 - name: ISSTA
   description: International Symposium on Software Testing and Analysis
   year: 2024
   link: https://conf.researchr.org/home/issta-2024
-  deadline: "2024-04-12"
-  notification_date: "2024-07-03"
-  date: "2024-09-16"
+  deadline: '2024-04-12'
+  notification_date: '2024-07-03'
+  date: '2024-09-16'
   place: Vienna, Austria
   note: Cycle 2/2
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Maria Christakis
   program_chair: Michael Pradel
-
+  series_link: https://www.issta.org/
 - name: ISSTA
   description: International Symposium on Software Testing and Analysis
   year: 2023
   link: https://conf.researchr.org/home/issta-2023
-  deadline: "2022-11-10"
-  notification_date: "2023-01-16"
-  date: "2023-07-17"
+  deadline: '2022-11-10'
+  notification_date: '2023-01-16'
+  date: '2023-07-17'
   place: Seattle, WA
   note: Cycle 1/2
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: René Just
   program_chair: Gordon Fraser
-
+  series_link: https://www.issta.org/
 - name: ISSTA
   description: International Symposium on Software Testing and Analysis
   year: 2023
   link: https://conf.researchr.org/home/issta-2023
-  deadline: "2023-02-16"
-  notification_date: "2023-03-03"
-  date: "2023-07-17"
+  deadline: '2023-02-16'
+  notification_date: '2023-03-03'
+  date: '2023-07-17'
   place: Seattle, WA
   note: Cycle 2/2
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: René Just
   program_chair: Gordon Fraser
-
+  series_link: https://www.issta.org/
 - name: ISSTA
   description: International Symposium on Software Testing and Analysis
   year: 2022
   link: https://conf.researchr.org/home/issta-2022
-  deadline: "2022-01-28"
-  notification_date: "2022-04-11"
+  deadline: '2022-01-28'
+  notification_date: '2022-04-11'
   note: Virtual conference
-  date: "2022-07-18"
+  date: '2022-07-18'
   place: Online
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Sukyoung Ryu
   program_chair: Yannis Smaragdakis
-
+  series_link: https://www.issta.org/
 - name: ISSTA
   description: International Symposium on Software Testing and Analysis
   year: 2021
   link: https://conf.researchr.org/home/issta-2021
-  deadline: "2021-01-29"
-  notification_date: "2021-04-19"
+  deadline: '2021-01-29'
+  notification_date: '2021-04-19'
   note: Virtual conference
-  date: "2021-07-11"
+  date: '2021-07-11'
   place: Online
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Cristian Cadar
   program_chair: Xiangyu Zhang
-
+  series_link: https://www.issta.org/
 - name: ISSTA
   description: International Symposium on Software Testing and Analysis
   year: 2020
   link: https://conf.researchr.org/home/issta-2020
-  deadline: "2020-01-27"
-  notification_date: "2020-04-15"
+  deadline: '2020-01-27'
+  notification_date: '2020-04-15'
   note: Virtual conference
-  date: "2020-07-18"
+  date: '2020-07-18'
   place: Online
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Sarfraz Khurshid
   program_chair: Corina S. Păsăreanu
-
+  series_link: https://www.issta.org/
 - name: ISSTA
   description: International Symposium on Software Testing and Analysis
   year: 2019
   link: https://conf.researchr.org/home/issta-2019
-  deadline: "2019-01-28"
-  notification_date: "2019-03-18"
+  deadline: '2019-01-28'
+  notification_date: '2019-03-18'
   note: Co-located with SPIN 2019
-  date: "2019-07-15"
+  date: '2019-07-15'
   place: Beijing, China
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Dongmei Zhang
   program_chair: Anders Møller
-
+  series_link: https://www.issta.org/
 - name: ISSTA
   description: International Symposium on Software Testing and Analysis
   year: 2018
   link: https://conf.researchr.org/home/issta-2018
-  deadline: "2018-01-29"
-  notification_date: "2018-03-19"
+  deadline: '2018-01-29'
+  notification_date: '2018-03-19'
   note: Co-located with ECOOP 2018
-  date: "2018-07-16"
+  date: '2018-07-16'
   place: Amsterdam, Netherlands
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Frank Tip
   program_chair: Eric Bodden
-
+  series_link: https://www.issta.org/
 - name: ISSTA
   description: International Symposium on Software Testing and Analysis
   year: 2017
   link: https://conf.researchr.org/home/issta-2017
-  deadline: "2017-02-03"
-  notification_date: "2017-04-29"
+  deadline: '2017-02-03'
+  notification_date: '2017-04-29'
   note: Co-located with SPIN 2017
-  date: "2017-07-10"
+  date: '2017-07-10'
   place: Santa Barbara, CA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Tevfik Bultan
   program_chair: Koushik Sen
-
+  series_link: https://www.issta.org/
 - name: ISSTA
   description: International Symposium on Software Testing and Analysis
   year: 2016
   link: https://conf.researchr.org/home/issta-2016
-  deadline: "2016-01-29"
+  deadline: '2016-01-29'
   note: Co-located with ECOOP 2016
-  date: "2016-07-18"
+  date: '2016-07-18'
   place: Rome, Italy
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
+  series_link: https://www.issta.org/
 - name: ISSTA
   description: International Symposium on Software Testing and Analysis
   year: 2015
   link: https://conf.researchr.org/home/issta-2015
-  deadline: "2015-01-30"
-  notification_date: "2015-04-01"
+  deadline: '2015-01-30'
+  notification_date: '2015-04-01'
   note: Co-located with ECOOP 2015
-  date: "2015-07-14"
+  date: '2015-07-14'
   place: Baltimore, MD
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Michal Young
   program_chair: Tao Xie
-
+  series_link: https://www.issta.org/
 - name: ICFP
   description: International Conference on Functional Programming
   year: 2026
   link: https://conf.researchr.org/home/icfp-2026
-  deadline: "2026-02-19"
-  rebuttal_date: "2026-04-20"
-  notification_date: "2026-05-14"
-  note: 
-  date: "2026-08-24"
+  deadline: '2026-02-19'
+  rebuttal_date: '2026-04-20'
+  notification_date: '2026-05-14'
+  note: null
+  date: '2026-08-24'
   place: Indianapolis, IN
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Sam Tobin-Hochstadt
   program_chair: Manuel Serrano
-
 - name: ICFP
   description: International Conference on Functional Programming
   year: 2025
   link: https://icfp25.sigplan.org/
-  deadline: "2025-02-27"
-  notification_date: "2025-03-23"
+  deadline: '2025-02-27'
+  notification_date: '2025-03-23'
   note: Co-located with SPLASH 2025
-  date: "2025-10-12"
+  date: '2025-10-12'
   place: Singapore
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Ilya Sergey
   program_chair: Dominique Devriese
-  
-
 - name: ICFP
   description: International Conference on Functional Programming
   year: 2024
   link: https://icfp24.sigplan.org/
-  deadline: "2024-02-28"
-  notification_date: "2024-03-20"
-  note:
-  date: "2024-09-02"
+  deadline: '2024-02-28'
+  notification_date: '2024-03-20'
+  note: null
+  date: '2024-09-02'
   place: Milan, Italy
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Marco Gaboardi
   program_chair: Brigitte Pientka
-
 - name: ICFP
   description: International Conference on Functional Programming
   year: 2023
   link: https://icfp23.sigplan.org/
-  deadline: "2023-03-01"
-  notification_date: "2023-05-18"
-  note:
-  date: "2023-09-04"
+  deadline: '2023-03-01'
+  notification_date: '2023-05-18'
+  note: null
+  date: '2023-09-04'
   place: Seattle, WA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Nikhil Swamy
   program_chair: Sam Lindley
-
-
 - name: ICFP
   description: International Conference on Functional Programming
   year: 2022
   link: https://icfp22.sigplan.org/
-  deadline: "2022-03-02"
-  notification_date: "2022-05-21"
-  note:
-  date: "2022-09-11"
+  deadline: '2022-03-02'
+  notification_date: '2022-05-21'
+  note: null
+  date: '2022-09-11'
   place: Ljubljana, Slovenia
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Andrej Bauer
   program_chair: Zena M. Ariola
-
 - name: ICFP
   description: International Conference on Functional Programming
   year: 2021
   link: https://icfp21.sigplan.org/
-  deadline: "2021-03-02"
-  notification_date: "2021-05-08"
+  deadline: '2021-03-02'
+  notification_date: '2021-05-08'
   note: Virtual conference
-  date: "2021-08-22"
+  date: '2021-08-22'
   place: Online
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Sukyoung Ryu
   program_chair: Ronald Garcia
-
 - name: ICFP
   description: International Conference on Functional Programming
   year: 2020
   link: https://icfp20.sigplan.org/
-  deadline: "2020-03-03"
-  notification_date: "2020-05-08"
+  deadline: '2020-03-03'
+  notification_date: '2020-05-08'
   note: Virtual conference
-  date: "2020-08-20"
+  date: '2020-08-20'
   place: Online
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Stephanie Weirich
   program_chair: Adam Chlipala
-
 - name: ICFP
   description: International Conference on Functional Programming
   year: 2019
   link: https://icfp19.sigplan.org/
-  deadline: "2019-03-01"
-  notification_date: "2019-05-03"
-  note:
-  date: "2019-08-18"
+  deadline: '2019-03-01'
+  notification_date: '2019-05-03'
+  note: null
+  date: '2019-08-18'
   place: Berlin, Germany
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Derek Dreyer
   program_chair: François Pottier
-
 - name: ICFP
   description: International Conference on Functional Programming
   year: 2018
   link: https://icfp18.sigplan.org/
-  deadline: "2018-03-16"
-  notification_date: "2018-05-18"
-  note:
-  date: "2018-09-23"
+  deadline: '2018-03-16'
+  notification_date: '2018-05-18'
+  note: null
+  date: '2018-09-23'
   place: St. Louis, MO
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: William E. Byrd
   program_chair: Matthew Flatt
-
 - name: ICFP
   description: International Conference on Functional Programming
   year: 2017
   link: https://icfp17.sigplan.org/
-  deadline: "2017-02-27"
-  notification_date: "2017-05-01"
-  note:
-  date: "2017-09-03"
+  deadline: '2017-02-27'
+  notification_date: '2017-05-01'
+  note: null
+  date: '2017-09-03'
   place: Oxford, UK
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jeremy Gibbons
   program_chair: Mark Jones
-
 - name: ICFP
   description: International Conference on Functional Programming
   year: 2016
   link: https://icfp16.sigplan.org/
-  deadline: "2016-03-16"
-  notification_date: "2016-05-20"
-  note:
-  date: "2016-09-18"
+  deadline: '2016-03-16'
+  notification_date: '2016-05-20'
+  note: null
+  date: '2016-09-18'
   place: Nara, Japan
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jacques Garrigue, Gabriele Keller
   program_chair: Eijiro Sumii
-
 - name: OOPSLA
   description: Object-Oriented Programming, Systems, Languages, and Applications
   year: 2026
   link: https://conf.researchr.org/track/splash-2026/oopsla-2026
-  deadline: "2026-03-17"
-  notification_date: "2026-06-10"
-  rebuttal_date: "2026-05-18"
-  date: "2026-10-03"
+  deadline: '2026-03-17'
+  notification_date: '2026-06-10'
+  rebuttal_date: '2026-05-18'
+  date: '2026-10-03'
   place: Oakland, CA
   note: Cycle 2/2
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Anders Møller, Işıl Dillig
-  program_chair: 
-
+  program_chair: null
+  series_link: https://oopsla.org/
 - name: OOPSLA
   description: Object-Oriented Programming, Systems, Languages, and Applications
   year: 2025
   link: https://2025.splashcon.org/track/OOPSLA
-  deadline: "2024-10-15"
-  notification_date: "2024-12-18"
-  date: "2025-10-12"
+  deadline: '2024-10-15'
+  notification_date: '2024-12-18'
+  date: '2025-10-12'
   place: Singapore
   note: Cycle 1/2
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Charles Zhang
-  program_chair: 
-
+  program_chair: null
+  series_link: https://oopsla.org/
 - name: OOPSLA
   description: Object-Oriented Programming, Systems, Languages, and Applications
   year: 2025
   link: https://2025.splashcon.org/track/OOPSLA
-  deadline: "2025-03-25"
-  notification_date: "2025-05-26"
-  date: "2025-10-12"
+  deadline: '2025-03-25'
+  notification_date: '2025-05-26'
+  date: '2025-10-12'
   place: Singapore
   note: Cycle 2/2
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Charles Zhang
-  program_chair: 
-
+  program_chair: null
+  series_link: https://oopsla.org/
 - name: OOPSLA
   description: Object-Oriented Programming, Systems, Languages, and Applications
   year: 2024
   link: https://2024.splashcon.org/track/splash-2024-OOPSLA
-  deadline: "2023-10-20"
-  notification_date: "2023-12-22"
-  date: "2024-10-20"
+  deadline: '2023-10-20'
+  notification_date: '2023-12-22'
+  date: '2024-10-20'
   place: Pasadena, CA
   note: Cycle 1/2
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Manu Sridharan
-  program_chair: 
-
+  program_chair: null
+  series_link: https://oopsla.org/
 - name: OOPSLA
   description: Object-Oriented Programming, Systems, Languages, and Applications
   year: 2024
   link: https://2024.splashcon.org/track/splash-2024-OOPSLA
-  deadline: "2024-04-05"
-  notification_date: "2024-06-21"
-  date: "2024-10-20"
+  deadline: '2024-04-05'
+  notification_date: '2024-06-21'
+  date: '2024-10-20'
   place: Pasadena, CA
   note: Cycle 2/2
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Manu Sridharan
-  program_chair: 
-
+  program_chair: null
+  series_link: https://oopsla.org/
 - name: OOPSLA
   description: Object-Oriented Programming, Systems, Languages, and Applications
   year: 2023
   link: https://2023.splashcon.org/track/splash-2023-oopsla
-  deadline: "2022-10-28"
-  notification_date: "2022-12-23"
-  date: "2023-10-22"
+  deadline: '2022-10-28'
+  notification_date: '2022-12-23'
+  date: '2023-10-22'
   place: Cascais, Portugal
   note: Cycle 1/2
-  acceptance_rate:
-  num_submission:
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Mira Mezini
-
+  series_link: https://oopsla.org/
 - name: OOPSLA
   description: Object-Oriented Programming, Systems, Languages, and Applications
   year: 2023
   link: https://2023.splashcon.org/track/splash-2023-oopsla
-  deadline: "2023-04-14"
-  notification_date: "2023-06-30"
-  date: "2023-10-22"
+  deadline: '2023-04-14'
+  notification_date: '2023-06-30'
+  date: '2023-10-22'
   place: Cascais, Portugal
   note: Cycle 2/2
-  acceptance_rate:
-  num_submission:
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Mira Mezini
-
-
+  series_link: https://oopsla.org/
 - name: OOPSLA
   description: Object-Oriented Programming, Systems, Languages, and Applications
   year: 2022
   link: https://2022.splashcon.org/track/splash-2022-oopsla
-  deadline: "2021-10-12"
-  notification_date: "2021-12-16"
-  date: "2022-12-05"
+  deadline: '2021-10-12'
+  notification_date: '2021-12-16'
+  date: '2022-12-05'
   place: Auckland, New Zealand
   note: Cycle 1/2
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Alex Potanin
-  program_chair: 
-
+  program_chair: null
+  series_link: https://oopsla.org/
 - name: OOPSLA
   description: Object-Oriented Programming, Systems, Languages, and Applications
   year: 2022
   link: https://2022.splashcon.org/track/splash-2022-oopsla
-  deadline: "2022-04-15"
-  notification_date: "2022-06-30"
-  date: "2022-12-05"
+  deadline: '2022-04-15'
+  notification_date: '2022-06-30'
+  date: '2022-12-05'
   place: Auckland, New Zealand
   note: Cycle 2/2
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Alex Potanin
-  program_chair: 
-
+  program_chair: null
+  series_link: https://oopsla.org/
 - name: OOPSLA
   description: Object-Oriented Programming, Systems, Languages, and Applications
   year: 2021
   link: https://2021.splashcon.org/track/splash-2021-oopsla
-  deadline: "2021-04-16"
-  notification_date: "2021-07-02"
-  date: "2021-10-17"
+  deadline: '2021-04-16'
+  notification_date: '2021-07-02'
+  date: '2021-10-17'
   place: Chicago, IL
   note: Cycle 1/2
-  acceptance_rate:
-  num_submission:
-  general_chair: 
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://oopsla.org/
 - name: OOPSLA
   description: Object-Oriented Programming, Systems, Languages, and Applications
   year: 2021
   link: https://2021.splashcon.org/track/splash-2021-oopsla
-  deadline: "2021-08-13"
-  notification_date: "2021-08-30"
-  date: "2021-10-17"
+  deadline: '2021-08-13'
+  notification_date: '2021-08-30'
+  date: '2021-10-17'
   place: Chicago, IL
   note: Cycle 2/2
-  acceptance_rate:
-  num_submission:
-  general_chair: 
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://oopsla.org/
 - name: OOPSLA
   description: Object-Oriented Programming, Systems, Languages, and Applications
   year: 2020
   link: https://2020.splashcon.org/track/splash-2020-oopsla
-  deadline: "2020-05-15"
-  notification_date: "2020-07-31"
-  date: "2020-11-15"
+  deadline: '2020-05-15'
+  notification_date: '2020-07-31'
+  date: '2020-11-15'
   place: Online
   note: Cycle 1/2
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Hridesh Rajan
-  program_chair:
-
+  program_chair: null
+  series_link: https://oopsla.org/
 - name: OOPSLA
   description: Object-Oriented Programming, Systems, Languages, and Applications
   year: 2020
   link: https://2020.splashcon.org/track/splash-2020-oopsla
-  deadline: "2020-09-14"
-  notification_date: "2020-10-01"
-  date: "2020-09-14"
+  deadline: '2020-09-14'
+  notification_date: '2020-10-01'
+  date: '2020-09-14'
   place: Online
   note: Cycle 2/2
-  acceptance_rate:
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Hridesh Rajan
-  program_chair:
-
+  program_chair: null
+  series_link: https://oopsla.org/
 - name: OOPSLA
   description: Object-Oriented Programming, Systems, Languages, and Applications
   year: 2019
   link: https://2019.splashcon.org/track/splash-2019-oopsla
-  deadline: "2019-04-05"
-  notification_date: "2019-07-01"
-  date: "2019-10-20"
+  deadline: '2019-04-05'
+  notification_date: '2019-07-01'
+  date: '2019-10-20'
   place: Athens, Greece
   note: Cycle 1/2
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Yannis Smaragdakis
-  program_chair:
-
+  program_chair: null
+  series_link: https://oopsla.org/
 - name: OOPSLA
   description: Object-Oriented Programming, Systems, Languages, and Applications
   year: 2019
   link: https://2019.splashcon.org/track/splash-2019-oopsla
-  deadline: "2019-08-15"
-  notification_date: "2019-09-01"
-  date: "2019-10-20"
+  deadline: '2019-08-15'
+  notification_date: '2019-09-01'
+  date: '2019-10-20'
   place: Athens, Greece
   note: Cycle 2/2
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Yannis Smaragdakis
-  program_chair:
-
+  program_chair: null
+  series_link: https://oopsla.org/
 - name: OOPSLA
   description: Object-Oriented Programming, Systems, Languages, and Applications
   year: 2018
   link: https://2018.splashcon.org/track/splash-2018-oopsla
-  deadline: "2018-04-16"
-  notification_date: "2018-06-25"
-  date: "2018-11-04"
+  deadline: '2018-04-16'
+  notification_date: '2018-06-25'
+  date: '2018-11-04'
   place: Boston, MA
   note: Cycle 1/2
-  acceptance_rate:
-  num_submission:
-  general_chair: 
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://oopsla.org/
 - name: OOPSLA
   description: Object-Oriented Programming, Systems, Languages, and Applications
   year: 2018
   link: https://2018.splashcon.org/track/splash-2018-oopsla
-  deadline: "2018-07-31"
-  notification_date: "2018-08-16"
-  date: "2018-11-04"
+  deadline: '2018-07-31'
+  notification_date: '2018-08-16'
+  date: '2018-11-04'
   place: Boston, MA
   note: Cycle 2/2
-  acceptance_rate:
-  num_submission:
-  general_chair: 
-  program_chair:
-  
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://oopsla.org/
 - name: OOPSLA
   description: Object-Oriented Programming, Systems, Languages, and Applications
   year: 2017
   link: https://2017.splashcon.org/track/splash-2017-OOPSLA
-  deadline: "2017-04-17"
-  abstract_deadline: "2017-04-13"
-  notification_date: "2017-06-21"
-  date: "2017-10-22"
+  deadline: '2017-04-17'
+  abstract_deadline: '2017-04-13'
+  notification_date: '2017-06-21'
+  date: '2017-10-22'
   place: Vancouver, Canada
   note: Cycle 1/2
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Jonathan Aldrich
-
+  series_link: https://oopsla.org/
 - name: OOPSLA
   description: Object-Oriented Programming, Systems, Languages, and Applications
   year: 2017
   link: https://2017.splashcon.org/track/splash-2017-OOPSLA
-  deadline: "2017-07-27"
-  abstract_deadline: "2017-04-13"
-  notification_date: "2017-08-11"
-  date: "2017-10-22"
+  deadline: '2017-07-27'
+  abstract_deadline: '2017-04-13'
+  notification_date: '2017-08-11'
+  date: '2017-10-22'
   place: Vancouver, Canada
   note: Cycle 2/2
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Jonathan Aldrich
-
+  series_link: https://oopsla.org/
 - name: OOPSLA
   description: Object-Oriented Programming, Systems, Languages, and Applications
   year: 2016
   link: https://2016.splashcon.org/track/splash-2016-oopsla
-  deadline: "2016-03-23"
-  notification_date: "2016-06-01"
-  date: "2016-10-30"
+  deadline: '2016-03-23'
+  notification_date: '2016-06-01'
+  date: '2016-10-30'
   place: Amsterdam, The Netherlands
-  note:
-  acceptance_rate:
-  num_submission:
+  note: null
+  acceptance_rate: null
+  num_submission: null
   general_chair: Eelco Visser
   program_chair: Yannis Smaragdakis
-
+  series_link: https://oopsla.org/
 - name: OOPSLA
   description: Object-Oriented Programming, Systems, Languages, and Applications
   year: 2016
   link: https://2016.splashcon.org/track/splash-2016-oopsla
-  deadline: "2016-07-19"
-  notification_date: "2016-08-03"
-  date: "2016-10-30"
+  deadline: '2016-07-19'
+  notification_date: '2016-08-03'
+  date: '2016-10-30'
   place: Amsterdam, The Netherlands
   note: Cycle 2/2
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Eelco Visser
   program_chair: Yannis Smaragdakis
-
+  series_link: https://oopsla.org/
 - name: OOPSLA
   description: Object-Oriented Programming, Systems, Languages, and Applications
   year: 2015
   link: https://2015.splashcon.org/track/oopsla2015
-  deadline: "2015-03-25"
-  notification_date: "2015-05-25"
-  date: "2015-10-23"
+  deadline: '2015-03-25'
+  notification_date: '2015-05-25'
+  date: '2015-10-23'
   place: Pittsburgh, PA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jonathan Aldrich
   program_chair: Patrick Eugster
-
+  series_link: https://oopsla.org/
 - name: PLDI
   description: Programming Language Design and Implementation
   year: 2026
   link: https://pldi26.sigplan.org/
-  deadline: "2025-11-13"
-  rebuttal_date: "2026-02-17"
-  notification_date: "2026-03-05"
-  note:
-  date: "2026-06-19"
+  deadline: '2025-11-13'
+  rebuttal_date: '2026-02-17'
+  notification_date: '2026-03-05'
+  note: null
+  date: '2026-06-19'
   place: Boulder, Colorado
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Manu Sridharan
-
-
 - name: PLDI
   description: Programming Language Design and Implementation
   year: 2025
   link: https://pldi25.sigplan.org/
-  deadline: "2024-11-14"
-  notification_date: "2025-03-06"
-  note:
-  date: "2025-06-16"
+  deadline: '2024-11-14'
+  notification_date: '2025-03-06'
+  note: null
+  date: '2025-06-16'
   place: Seoul, South Korea
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Zachary Tatlock
-
 - name: PLDI
   description: Programming Language Design and Implementation
   year: 2024
   link: https://pldi24.sigplan.org/
-  deadline: "2023-11-16"
-  notification_date: "2024-02-26"
-  note:
-  date: "2024-06-24"
+  deadline: '2023-11-16'
+  notification_date: '2024-02-26'
+  note: null
+  date: '2024-06-24'
   place: Copenhagen, Denmark
-  acceptance_rate:
-  num_submission:
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: John Regehr
-
 - name: PLDI
   description: Programming Language Design and Implementation
   year: 2023
   link: https://pldi23.sigplan.org/
-  deadline: "2022-11-10"
-  notification_date: "2023-02-24"
-  note:
-  date: "2023-06-17"
+  deadline: '2022-11-10'
+  notification_date: '2023-02-24'
+  note: null
+  date: '2023-06-17'
   place: Orlando, FL
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Steve Blackburn
   program_chair: Nate Foster
-
 - name: PLDI
   description: Programming Language Design and Implementation
   year: 2022
   link: https://pldi22.sigplan.org/
-  deadline: "2021-11-19"
-  notification_date: "2022-02-25"
-  note:
-  date: "2022-06-13"
+  deadline: '2021-11-19'
+  notification_date: '2022-02-25'
+  note: null
+  date: '2022-06-13'
   place: San Diego, CA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Ranjit Jhala
   program_chair: Işıl Dillig
-
 - name: PLDI
   description: Programming Language Design and Implementation
   year: 2021
   link: https://pldi21.sigplan.org/
-  deadline: "2020-11-20"
-  notification_date: "2021-02-25"
+  deadline: '2020-11-20'
+  notification_date: '2021-02-25'
   note: Virtual conference
-  date: "2021-06-20"
+  date: '2021-06-20'
   place: Online
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Stephen N. Freund
   program_chair: Eran Yahav
-
 - name: PLDI
   description: Programming Language Design and Implementation
   year: 2020
   link: https://pldi20.sigplan.org/
-  deadline: "2019-11-22"
-  notification_date: "2020-02-21"
+  deadline: '2019-11-22'
+  notification_date: '2020-02-21'
   note: Virtual conference
-  date: "2020-06-15"
+  date: '2020-06-15'
   place: Online
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Alastair F. Donaldson
   program_chair: Emina Torlak
-
 - name: PLDI
   description: Programming Language Design and Implementation
   year: 2019
   link: https://pldi19.sigplan.org/
-  deadline: "2018-11-16"
-  notification_date: "2019-02-15"
-  note:
-  date: "2019-06-22"
+  deadline: '2018-11-16'
+  notification_date: '2019-02-15'
+  note: null
+  date: '2019-06-22'
   place: Phoenix, AZ
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Kathryn S. McKinley
   program_chair: Kathleen Fisher
-
 - name: PLDI
   description: Programming Language Design and Implementation
   year: 2018
   link: https://pldi18.sigplan.org/
-  deadline: "2017-11-16"
-  notification_date: "2018-02-13"
-  note:
-  date: "2018-06-18"
+  deadline: '2017-11-16'
+  notification_date: '2018-02-13'
+  note: null
+  date: '2018-06-18'
   place: Philadelphia, PA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jeffrey S. Foster
   program_chair: Dan Grossman
-
 - name: PLDI
   description: Programming Language Design and Implementation
   year: 2017
   link: https://pldi17.sigplan.org/
-  deadline: "2016-11-15"
-  notification_date: "2017-02-13"
-  note:
-  date: "2017-06-18"
+  deadline: '2016-11-15'
+  notification_date: '2017-02-13'
+  note: null
+  date: '2017-06-18'
   place: Barcelona, Spain
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Albert Cohen
   program_chair: Martin Vechev
-
 - name: PLDI
   description: Programming Language Design and Implementation
   year: 2016
   link: https://pldi16.sigplan.org/
-  deadline: "2015-11-20"
-  notification_date: "2016-02-20"
-  note:
-  date: "2016-06-13"
+  deadline: '2015-11-20'
+  notification_date: '2016-02-20'
+  note: null
+  date: '2016-06-13'
   place: Santa Barbara, CA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Chandra Krintz
   program_chair: Emery D. Berger
-
 - name: PLDI
   description: Programming Language Design and Implementation
   year: 2015
   link: https://pldi15.sigplan.org/
-  deadline: "2014-11-13"
-  notification_date: "2014-12-19"
-  note:
-  date: "2015-06-13"
+  deadline: '2014-11-13'
+  notification_date: '2014-12-19'
+  note: null
+  date: '2015-06-13'
   place: Portland, OR
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: David Grove
   program_chair: Steve Blackburn
-
-
 - name: POPL
   description: Principles of Programming Languages
   year: 2026
   link: https://conf.researchr.org/home/POPL-2026
-  deadline: "2025-07-10"
-  notification_date: "2025-10-02"
-  note: 
-  date: "2026-01-11"
+  deadline: '2025-07-10'
+  notification_date: '2025-10-02'
+  note: null
+  date: '2026-01-11'
   place: Rennes, France
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Sandrine Blazy
   program_chair: Suresh Jagannathan
-
 - name: POPL
   description: Principles of Programming Languages
   year: 2025
   link: https://conf.researchr.org/home/POPL-2025
-  deadline: "2024-07-11"
-  notification_date: "2024-10-08"
-  note: 
-  date: "2025-01-19"
+  deadline: '2024-07-11'
+  notification_date: '2024-10-08'
+  note: null
+  date: '2025-01-19'
   place: Denver, CO
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Steve Zdancewic
   program_chair: Armando Solar-Lezama
-
 - name: POPL
   description: Principles of Programming Languages
   year: 2024
   link: https://conf.researchr.org/home/POPL-2024
-  deadline: "2023-07-11"
-  notification_date: "2023-10-02"
-  note: 
-  date: "2024-01-14"
+  deadline: '2023-07-11'
+  notification_date: '2023-10-02'
+  note: null
+  date: '2024-01-14'
   place: London, United Kingdom
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Philippa Gardner
   program_chair: Derek Dreyer
-
 - name: POPL
   description: Principles of Programming Languages
   year: 2023
   link: https://conf.researchr.org/home/POPL-2023
-  deadline: "2022-07-07"
-  notification_date: "2022-09-27"
-  note: 
-  date: "2023-01-15"
+  deadline: '2022-07-07'
+  notification_date: '2022-09-27'
+  note: null
+  date: '2023-01-15'
   place: Boston, MA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Andrew Myers
   program_chair: Amal Ahmed
-
 - name: POPL
   description: Principles of Programming Languages
   year: 2022
   link: https://conf.researchr.org/home/POPL-2022
-  deadline: "2021-07-08"
-  notification_date: "2021-09-29"
-  note: 
-  date: "2022-01-16"
+  deadline: '2021-07-08'
+  notification_date: '2021-09-29'
+  note: null
+  date: '2022-01-16'
   place: Philadelphia, PA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Rajeev Alur
   program_chair: Hongseok Yang
-  
-
 - name: POPL
   description: Principles of Programming Languages
   year: 2021
   link: https://conf.researchr.org/home/POPL-2021
-  deadline: "2020-07-09"
-  notification_date: "2020-10-01"
-  note: 
-  date: "2021-01-17"
+  deadline: '2020-07-09'
+  notification_date: '2020-10-01'
+  note: null
+  date: '2021-01-17'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Andreas Podelski
   program_chair: Azadeh Farzan
-
 - name: POPL
   description: Principles of Programming Languages
   year: 2020
   link: https://conf.researchr.org/home/POPL-2020
-  deadline: "2019-07-10"
-  notification_date: "2019-10-14"
-  note: 
-  date: "2020-01-19"
+  deadline: '2019-07-10'
+  notification_date: '2019-10-14'
+  note: null
+  date: '2020-01-19'
   place: New Orleans, LA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Brigitte Pientka
   program_chair: Lars Birkedal
-
 - name: POPL
   description: Principles of Programming Languages
   year: 2019
   link: https://conf.researchr.org/home/POPL-2019
-  deadline: "2018-07-11"
-  notification_date: "2018-10-10"
-  note: 
-  date: "2019-01-13"
+  deadline: '2018-07-11'
+  notification_date: '2018-10-10'
+  note: null
+  date: '2019-01-13'
   place: Cascais, Portugal
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Fritz Henglein
   program_chair: Stephanie Weirich
-
 - name: POPL
   description: Principles of Programming Languages
   year: 2018
   link: https://conf.researchr.org/home/POPL-2018
-  deadline: "2017-07-07"
-  notification_date: "2017-09-29"
-  note: 
-  date: "2018-01-07"
+  deadline: '2017-07-07'
+  notification_date: '2017-09-29'
+  note: null
+  date: '2018-01-07'
   place: Los Angeles, CA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Ranjit Jhala
   program_chair: Andrew Myers
-
 - name: POPL
   description: Principles of Programming Languages
   year: 2017
   link: https://conf.researchr.org/home/POPL-2017
-  deadline: "2016-07-06"
-  abstract_deadline: "2016-07-01"
-  notification_date: "2016-10-03"
-  note: 
-  date: "2017-01-15"
+  deadline: '2016-07-06'
+  abstract_deadline: '2016-07-01'
+  notification_date: '2016-10-03'
+  note: null
+  date: '2017-01-15'
   place: Paris, France
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Giuseppe Castagna
   program_chair: Andrew D. Gordon
-
 - name: POPL
   description: Principles of Programming Languages
   year: 2016
   link: https://conf.researchr.org/home/POPL-2016
-  deadline: "2015-07-10"
-  abstract_deadline: "2015-07-03"
-  notification_date: "2015-10-05"
-  note: 
-  date: "2016-01-20"
+  deadline: '2015-07-10'
+  abstract_deadline: '2015-07-03'
+  notification_date: '2015-10-05'
+  note: null
+  date: '2016-01-20'
   place: St. Petersburg, FL
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Rastislav Bodík
   program_chair: Rupak Majumdar
-
 - name: POPL
   description: Principles of Programming Languages
   year: 2015
   link: https://popl.mpi-sws.org/2015/
-  deadline: "2014-07-08"
-  abstract_deadline: "2014-07-03"
-  notification_date: "2014-09-30"
-  note: 
-  date: "2015-01-12"
+  deadline: '2014-07-08'
+  abstract_deadline: '2014-07-03'
+  notification_date: '2014-09-30'
+  note: null
+  date: '2015-01-12'
   place: Mumbai, India
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Sriram Rajamani
   program_chair: David Walker
-
 - name: CAV
   description: International Conference on Computer Aided Verification
   year: 2026
   link: https://conferences.i-cav.org/2026/
-  deadline: "2026-01-28"
-  rebuttal_date: "2026-03-30"
-  notification_date: "2026-04-17"
-  note: 
-  date: "2026-07-26"
+  deadline: '2026-01-28'
+  rebuttal_date: '2026-03-30'
+  notification_date: '2026-04-17'
+  note: null
+  date: '2026-07-26'
   place: Lisbon, Portugal
-  acceptance_rate:
-  num_submission:
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Anthony W. Lin, Eva Darulova, Philipp Rümmer
-
+  series_link: https://cav.org/
 - name: CAV
   description: Computer Aided Verification
   year: 2025
   link: https://conferences.i-cav.org/2025/
-  deadline: "2025-01-31"
-  notification_date: "2025-04-02"
-  note: 
-  date: "2025-07-21"
+  deadline: '2025-01-31'
+  notification_date: '2025-04-02'
+  note: null
+  date: '2025-07-21'
   place: Zagreb, Croatia
-  acceptance_rate:
-  num_submission:
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Ruzica Piskac, Zvonimir Rakamaric
-
-
+  series_link: https://cav.org/
 - name: CAV
   description: Computer Aided Verification
   year: 2024
   link: https://i-cav.org/2024/
-  deadline: "2024-01-19"
-  notification_date: "2024-03-26"
-  note: 
-  date: "2024-07-22"
+  deadline: '2024-01-19'
+  notification_date: '2024-03-26'
+  note: null
+  date: '2024-07-22'
   place: Montreal, Canada
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Arie Gurfinkel, Vijay Ganesh
-
+  series_link: https://cav.org/
 - name: CAV
   description: Computer Aided Verification
   year: 2023
   link: https://i-cav.org/2023/
-  deadline: "2023-02-03"
-  notification_date: "2023-04-21"
-  note: 
-  date: "2023-07-17"
+  deadline: '2023-02-03'
+  notification_date: '2023-04-21'
+  note: null
+  date: '2023-07-17'
   place: Paris, France
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Constantin Enea, Akash Lal
-
+  series_link: https://cav.org/
 - name: CAV
   description: Computer Aided Verification
   year: 2022
   link: https://i-cav.org/2022/
-  deadline: "2022-01-21"
-  notification_date: "2022-04-30"
-  note: 
-  date: "2022-08-07"
+  deadline: '2022-01-21'
+  notification_date: '2022-04-30'
+  note: null
+  date: '2022-08-07'
   place: Haifa, Israel
-  acceptance_rate:
-  num_submission:
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Sharon Shoham, Yakir Vizel
-
+  series_link: https://cav.org/
 - name: CAV
   description: Computer Aided Verification
   year: 2021
   link: https://i-cav.org/2021/
-  deadline: "2021-01-28"
-  notification_date: "2021-04-19"
-  note: 
-  date: "2021-07-18"
+  deadline: '2021-01-28'
+  notification_date: '2021-04-19'
+  note: null
+  date: '2021-07-18'
   place: Online
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Rustan Leino, Alexandra Silva
-
+  series_link: https://cav.org/
 - name: CAV
   description: Computer Aided Verification
   year: 2020
   link: https://i-cav.org/2020/
-  deadline: "2020-01-28"
-  notification_date: "2020-04-06"
-  note: 
-  date: "2020-07-21"
+  deadline: '2020-01-28'
+  notification_date: '2020-04-06'
+  note: null
+  date: '2020-07-21'
   place: Online
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Shuvendu Lahiri, Chao Wang
-
+  series_link: https://cav.org/
 - name: CAV
   description: Computer Aided Verification
   year: 2019
   link: https://i-cav.org/2019/
-  deadline: "2019-02-07"
-  notification_date: "2019-04-17"
-  note: 
-  date: "2019-07-15"
+  deadline: '2019-02-07'
+  notification_date: '2019-04-17'
+  note: null
+  date: '2019-07-15'
   place: New York City, NY
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Isil Dillig, Serdar Tasiran
-
+  series_link: https://cav.org/
 - name: CAV
   description: Computer Aided Verification
   year: 2018
   link: https://i-cav.org/2018/
-  deadline: "2018-01-31"
-  notification_date: "2018-03-31"
+  deadline: '2018-01-31'
+  notification_date: '2018-03-31'
   note: Co-located with FLoC 2018
-  date: "2018-07-14"
+  date: '2018-07-14'
   place: Oxford, UK
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Hana Chockler, Georg Weissenbacher
-
+  series_link: https://cav.org/
 - name: CAV
   description: Computer Aided Verification
   year: 2017
   link: https://i-cav.org/2017/
-  deadline: "2017-01-24"
-  notification_date: "2017-04-12"
-  note: 
-  date: "2017-07-24"
+  deadline: '2017-01-24'
+  notification_date: '2017-04-12'
+  note: null
+  date: '2017-07-24'
   place: Heidelberg, Germany
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Viktor Kuncak, Rupak Majumdar
-
+  series_link: https://cav.org/
 - name: CAV
   description: Computer Aided Verification
   year: 2016
   link: https://i-cav.org/2016/
-  deadline: "2016-01-29"
-  abstract_deadline: "2016-01-24"
-  notification_date: "2016-04-15"
-  note: 
-  date: "2016-07-17"
+  deadline: '2016-01-29'
+  abstract_deadline: '2016-01-24'
+  notification_date: '2016-04-15'
+  note: null
+  date: '2016-07-17'
   place: Toronto, Canada
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Swarat Chaudhuri, Azadeh Farzan
-
+  series_link: https://cav.org/
 - name: CAV
   description: Computer Aided Verification
   year: 2015
   link: https://i-cav.org/2015/
-  deadline: "2015-02-06"
-  abstract_deadline: "2015-01-30"
-  notification_date: "2015-04-17"
-  note: 
-  date: "2015-07-18"
+  deadline: '2015-02-06'
+  abstract_deadline: '2015-01-30'
+  notification_date: '2015-04-17'
+  note: null
+  date: '2015-07-18'
   place: San Francisco, CA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Daniel Kroening, Corina Pasareanu
-
+  series_link: https://cav.org/
 - name: LICS
   description: ACM/IEEE Symposium on Logic in Computer Science
   year: 2024
   link: https://lics.siglog.org/lics24/
-  deadline: "2024-01-26"
-  abstract_deadline: "2024-01-21"
-  notification_date: "2024-04-15"
-  date: "2024-07-08"
+  deadline: '2024-01-26'
+  abstract_deadline: '2024-01-21'
+  notification_date: '2024-04-15'
+  date: '2024-07-08'
   place: Tallinn, Estonia
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://siglog.org/lics26/
 - name: LICS
   description: ACM/IEEE Symposium on Logic in Computer Science
   year: 2023
   link: https://lics.siglog.org/lics23/
-  deadline: "2023-01-23"
-  abstract_deadline: "2023-01-18"
-  notification_date: "2023-04-05"
-  date: "2023-06-26"
+  deadline: '2023-01-23'
+  abstract_deadline: '2023-01-18'
+  notification_date: '2023-04-05'
+  date: '2023-06-26'
   place: Boston, MA, USA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://siglog.org/lics26/
 - name: LICS
   description: ACM/IEEE Symposium on Logic in Computer Science
   year: 2022
   link: https://lics.siglog.org/lics22/
-  deadline: "2022-01-21"
-  abstract_deadline: "2022-01-17"
-  notification_date: "2022-04-14"
-  date: "2022-08-02"
+  deadline: '2022-01-21'
+  abstract_deadline: '2022-01-17'
+  notification_date: '2022-04-14'
+  date: '2022-08-02'
   place: Haifa, Israel
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://siglog.org/lics26/
 - name: LICS
   description: ACM/IEEE Symposium on Logic in Computer Science
   year: 2021
   link: https://easyconferences.eu/lics2021/
-  deadline: "2021-01-25"
-  abstract_deadline: "2021-01-20"
-  notification_date: "2021-03-31"
-  date: "2021-06-29"
+  deadline: '2021-01-25'
+  abstract_deadline: '2021-01-20'
+  notification_date: '2021-03-31'
+  date: '2021-06-29'
   place: Online
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Daniele Gorla
   program_chair: Leonid Libkin
-
+  series_link: https://siglog.org/lics26/
 - name: LICS
   description: ACM/IEEE Symposium on Logic in Computer Science
   year: 2020
   link: https://lics.siglog.org/lics20/
-  deadline: "2020-01-10"
-  abstract_deadline: "2020-01-06"
-  notification_date: "2020-04-10"
-  date: "2020-07-08"
+  deadline: '2020-01-10'
+  abstract_deadline: '2020-01-06'
+  notification_date: '2020-04-10'
+  date: '2020-07-08'
   place: Saarbrücken, Germany (held virtually)
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
-  program_chair: Naoki Kobayashi 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: Naoki Kobayashi
+  series_link: https://siglog.org/lics26/
 - name: LICS
   description: ACM/IEEE Symposium on Logic in Computer Science
   year: 2019
   link: https://lics.siglog.org/lics19/
-  deadline: "2019-01-11"
-  abstract_deadline: "2019-01-04"
-  notification_date: "2019-03-29"
-  date: "2019-06-24"
+  deadline: '2019-01-11'
+  abstract_deadline: '2019-01-04'
+  notification_date: '2019-03-29'
+  date: '2019-06-24'
   place: Vancouver, Canada
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Patricia Bouyer,
-
+  series_link: https://siglog.org/lics26/
 - name: LICS
   description: ACM/IEEE Symposium on Logic in Computer Science
   year: 2018
   link: https://lics.siglog.org/lics18/
-  deadline: "2018-01-31"
-  abstract_deadline: "2018-01-124"
-  notification_date: "2018-03-31"
-  date: "2018-07-09"
+  deadline: '2018-01-31'
+  abstract_deadline: 2018-01-124
+  notification_date: '2018-03-31'
+  date: '2018-07-09'
   place: Oxford, United Kingdom
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Martin Hofmann, Anuj Dawar, Erich Grädel
-
+  series_link: https://siglog.org/lics26/
 - name: LICS
   description: ACM/IEEE Symposium on Logic in Computer Science
   year: 2017
   link: https://lics.siglog.org/lics17/
-  deadline: "2017-01-09"
-  abstract_deadline: "2017-01-03"
-  notification_date: "2017-03-21"
-  date: "2017-06-20"
+  deadline: '2017-01-09'
+  abstract_deadline: '2017-01-03'
+  notification_date: '2017-03-21'
+  date: '2017-06-20'
   place: Reykjavik, Iceland
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Martin Grohe
   program_chair: Joel Ouaknine
-
+  series_link: https://siglog.org/lics26/
 - name: LICS
   description: ACM/IEEE Symposium on Logic in Computer Science
   year: 2016
   link: https://lics.siglog.org/lics16/
-  deadline: "2016-01-18"
-  abstract_deadline: "2016-01-11"
-  notification_date: "2016-04-04"
-  date: "2016-07-05"
+  deadline: '2016-01-18'
+  abstract_deadline: '2016-01-11'
+  notification_date: '2016-04-04'
+  date: '2016-07-05'
   place: New York City, NY, USA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Martin Grohe
   program_chair: Natarajan Shankar
-
+  series_link: https://siglog.org/lics26/
 - name: LICS
   description: ACM/IEEE Symposium on Logic in Computer Science
   year: 2015
   link: https://lics.siglog.org/lics15/
-  deadline: "2015-01-19"
-  abstract_deadline: "2015-01-12"
-  notification_date: "2015-03-30"
-  date: "2015-07-06"
+  deadline: '2015-01-19'
+  abstract_deadline: '2015-01-12'
+  notification_date: '2015-03-30'
+  date: '2015-07-06'
   place: Kyoto, Japan
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Luke Ong
   program_chair: Catuscia Palamidessi
-
+  series_link: https://siglog.org/lics26/
 - name: IMC
   description: ACM Internet Measurement Conference
   year: 2025
   link: https://conferences.sigcomm.org/imc/2025/
-  deadline: "2025-05-15"
-  abstract_deadline: "2025-05-08"
-  notification_date: "2025-08-18"
+  deadline: '2025-05-15'
+  abstract_deadline: '2025-05-08'
+  notification_date: '2025-08-18'
   note: Cycle 2/2
-  date: "2025-10-28"
+  date: '2025-10-28'
   place: Madison, WI
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Paul Barford
-  program_chair: Alberto Dainotti, Aruna Balasubramanian 
-
+  program_chair: Alberto Dainotti, Aruna Balasubramanian
+  series_link: https://imc.org/
 - name: IMC
   description: ACM Internet Measurement Conference
   year: 2025
   link: https://conferences.sigcomm.org/imc/2025/
-  abstract_deadline: "2024-11-14"
-  deadline: "2024-11-21"
-  notification_date: "2025-03-26"
+  abstract_deadline: '2024-11-14'
+  deadline: '2024-11-21'
+  notification_date: '2025-03-26'
   note: Cycle 1/2
-  date: "2025-10-28"
+  date: '2025-10-28'
   place: Madison, WI
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Paul Barford
-  program_chair: Alberto Dainotti, Aruna Balasubramanian 
-
+  program_chair: Alberto Dainotti, Aruna Balasubramanian
+  series_link: https://imc.org/
 - name: IMC
   description: ACM Internet Measurement Conference
   year: 2024
   link: https://conferences.sigcomm.org/imc/2024/
-  deadline: "2024-05-15"
-  abstract_deadline: "2024-05-08"
-  notification_date: "2024-07-31"
-  note: 
-  date: "2024-11-04"
+  deadline: '2024-05-15'
+  abstract_deadline: '2024-05-08'
+  notification_date: '2024-07-31'
+  note: null
+  date: '2024-11-04'
   place: Madrid, Spain
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Narseo Vallina-Rodriguez, Guillermo Suarez-Tangil
   program_chair: Dave Levin, Cristel Pelsser
-
+  series_link: https://imc.org/
 - name: IMC
   description: ACM Internet Measurement Conference
   year: 2023
   link: https://conferences.sigcomm.org/imc/2023/
-  deadline: "2023-05-26"
-  abstract_deadline: "2023-05-20"
-  notification_date: "2023-08-18"
-  date: "2023-10-24"
+  deadline: '2023-05-26'
+  abstract_deadline: '2023-05-20'
+  notification_date: '2023-08-18'
+  date: '2023-10-24'
   place: Montreal, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Marie-José Montpetit, Aris Leivadeas
   program_chair: Steve Uhlig, Mobin Javed
-
+  series_link: https://imc.org/
 - name: IMC
   description: ACM Internet Measurement Conference
   year: 2022
   link: https://conferences.sigcomm.org/imc/2022/
-  deadline: "2022-05-18"
-  abstract_deadline: "2022-05-11"
-  notification_date: "2022-08-19"
-  date: "2022-10-25"
+  deadline: '2022-05-18'
+  abstract_deadline: '2022-05-11'
+  notification_date: '2022-08-19'
+  date: '2022-10-25'
   place: Nice, France
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Chadi Barakat, Cristel Pelsser
   program_chair: Theophilus Benson, David Choffnes
-
+  series_link: https://imc.org/
 - name: IMC
   description: ACM Internet Measurement Conference
   year: 2021
   link: https://conferences.sigcomm.org/imc/2021/
-  deadline: "2021-05-26"
-  abstract_deadline: "2021-05-19"
-  notification_date: "2021-08-18"
-  date: "2021-11-02"
+  deadline: '2021-05-26'
+  abstract_deadline: '2021-05-19'
+  notification_date: '2021-08-18'
+  date: '2021-11-02'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Dave Levin, Alan Mislove
   program_chair: Johanna Amann, Matthew Luckie
-
+  series_link: https://imc.org/
 - name: IMC
   description: ACM Internet Measurement Conference
   year: 2020
   link: https://conferences.sigcomm.org/imc/2020/
-  deadline: "2020-05-26"
-  abstract_deadline: "2020-05-19"
-  notification_date: "2020-08-12"
-  date: "2020-10-27"
+  deadline: '2020-05-26'
+  abstract_deadline: '2020-05-19'
+  notification_date: '2020-08-12'
+  date: '2020-10-27'
   place: Pittsburgh, PA
-  acceptance_rate:
-  num_submission:
-  general_chair: Nicolas Christin, Konstantinos Pelechrinis, Vyas Sekar 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Nicolas Christin, Konstantinos Pelechrinis, Vyas Sekar
   program_chair: Fabián Bustamante, Nick Feamster
-
+  series_link: https://imc.org/
 - name: IMC
   description: ACM Internet Measurement Conference
   year: 2019
   link: https://conferences.sigcomm.org/imc/2019/
-  deadline: "2019-05-13"
-  abstract_deadline: "2019-05-06"
-  notification_date: "2019-07-19"
-  date: "2019-10-21"
+  deadline: '2019-05-13'
+  abstract_deadline: '2019-05-06'
+  notification_date: '2019-07-19'
+  date: '2019-10-21'
   place: Amsterdam, Netherlands
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Anna Sperotto, Roland van Rijswijk-Deij, Cristian Hesselman
   program_chair: Phillipa Gill, Robert Beverly
-
+  series_link: https://imc.org/
 - name: IMC
   description: ACM Internet Measurement Conference
   year: 2018
   link: https://conferences.sigcomm.org/imc/2018/
-  deadline: "2018-05-25"
-  abstract_deadline: "2018-05-18"
-  notification_date: "2018-07-31"
-  date: "2018-10-31"
+  deadline: '2018-05-25'
+  abstract_deadline: '2018-05-18'
+  notification_date: '2018-07-31'
+  date: '2018-10-31'
   place: Boston, MA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Alan Mislove, David Choffnes, Christo Wilson
   program_chair: Ben Y. Zhao, Ethan Katz-Bassett
-
+  series_link: https://imc.org/
 - name: IMC
   description: ACM Internet Measurement Conference
   year: 2017
   link: https://conferences.sigcomm.org/imc/2017/
-  deadline: "2017-05-19"
-  abstract_deadline: "2017-05-12"
-  date: "2017-11-01"
+  deadline: '2017-05-19'
+  abstract_deadline: '2017-05-12'
+  date: '2017-11-01'
   place: London, United Kingdom
-  acceptance_rate:
-  num_submission:
-
+  acceptance_rate: null
+  num_submission: null
+  series_link: https://imc.org/
 - name: IMC
   description: ACM Internet Measurement Conference
   year: 2016
   link: https://conferences.sigcomm.org/imc/2016/
-  deadline: "2016-05-18"
-  abstract_deadline: "2016-05-11"
-  notification_date: "2016-07-31"
-  date: "2016-11-14"
+  deadline: '2016-05-18'
+  abstract_deadline: '2016-05-11'
+  notification_date: '2016-07-31'
+  date: '2016-11-14'
   place: Santa Monica, CA, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Steve Uhlig, Olaf Maennel
-  program_chair: Renata Cruz, Geoffrey M. Voelker 
-
-
-# CORE
+  program_chair: Renata Cruz, Geoffrey M. Voelker
+  series_link: https://imc.org/
 - name: CGO
   description: IEEE/ACM International Symposium on Code Generation and Optimization
   year: 2025
   link: https://conf.researchr.org/home/cgo-2025
-  deadline: "2024-09-12"
-  abstract_deadline: 
-  notification_date: "2024-11-04"
+  deadline: '2024-09-12'
+  abstract_deadline: null
+  notification_date: '2024-11-04'
   note: Cycle 2/2
-  date: "2025-03-01"
+  date: '2025-03-01'
   place: Las Vegas, NV, USA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Johannes Doerfert, Tobias Grosser
   program_chair: Hugh Leather, Saday Sadayappan
-
+  series_link: https://2026.cgo.org/
 - name: CGO
   description: IEEE/ACM International Symposium on Code Generation and Optimization
   year: 2025
   link: https://conf.researchr.org/home/cgo-2025
-  deadline: "2024-05-30"
-  abstract_deadline: 
-  notification_date: "2023-07-22"
+  deadline: '2024-05-30'
+  abstract_deadline: null
+  notification_date: '2023-07-22'
   note: Cycle 1/2
-  date: "2025-03-01"
+  date: '2025-03-01'
   place: Las Vegas, NV, USA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Johannes Doerfert, Tobias Grosser
   program_chair: Hugh Leather, Saday Sadayappan
-
+  series_link: https://2026.cgo.org/
 - name: CGO
   description: IEEE/ACM International Symposium on Code Generation and Optimization
   year: 2024
   link: https://conf.researchr.org/home/cgo-2024
-  deadline: "2023-05-19"
-  abstract_deadline: 
-  notification_date: "2023-07-31"
-  date: "2024-03-02"
+  deadline: '2023-05-19'
+  abstract_deadline: null
+  notification_date: '2023-07-31'
+  date: '2024-03-02'
   place: Edinburgh, United Kingdom
   note: Cycle 1/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Tobias Grosser, Christophe Dubach
   program_chair: Miichael Steuwer, Jingling Xue
-
-
+  series_link: https://2026.cgo.org/
 - name: CGO
   description: IEEE/ACM International Symposium on Code Generation and Optimization
   year: 2024
   link: https://conf.researchr.org/home/cgo-2024
-  deadline: "2023-09-01"
-  abstract_deadline: 
-  notification_date: "2023-11-06"
-  date: "2024-03-02"
+  deadline: '2023-09-01'
+  abstract_deadline: null
+  notification_date: '2023-11-06'
+  date: '2024-03-02'
   place: Edinburgh, United Kingdom
   note: Cycle 2/2
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Tobias Grosser, Christophe Dubach
   program_chair: Guilherme Ottoni, Fernando Magno Quintao Pereira
-
+  series_link: https://2026.cgo.org/
 - name: CGO
   description: IEEE/ACM International Symposium on Code Generation and Optimization
   year: 2023
   link: https://conf.researchr.org/home/cgo-2023
-  deadline: "2022-09-02"
-  abstract_deadline: 
-  notification_date: "2022-11-07"
-  date: "2023-02-25"
+  deadline: '2022-09-02'
+  abstract_deadline: null
+  notification_date: '2022-11-07'
+  date: '2023-02-25'
   place: Montreal, Canada
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Christophe Dubach
   program_chair: Derek Bruening, Ben Hardekopf
-
+  series_link: https://2026.cgo.org/
 - name: CGO
   description: IEEE/ACM International Symposium on Code Generation and Optimization
   year: 2022
   link: https://conf.researchr.org/home/cgo-2022
-  deadline: "2021-09-03"
-  abstract_deadline: "2021-08-27"
-  notification_date: "2021-11-05"
-  date: "2022-04-02"
+  deadline: '2021-09-03'
+  abstract_deadline: '2021-08-27'
+  notification_date: '2021-11-05'
+  date: '2022-04-02'
   place: Seoul, South Korea (Virtual Conference)
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jae W. Lee
   program_chair: Sebastian Hack, Tatiana Shpeisman
-
+  series_link: https://2026.cgo.org/
 - name: CGO
   description: IEEE/ACM International Symposium on Code Generation and Optimization
   year: 2021
   link: https://conf.researchr.org/home/cgo-2021
-  deadline: "2020-09-01"
-  abstract_deadline: "2020-08-25"
-  notification_date: "2020-11-05"
-  date: "2021-02-27"
+  deadline: '2020-09-01'
+  abstract_deadline: '2020-08-25'
+  notification_date: '2020-11-05'
+  date: '2021-02-27'
   place: Virtual Conference
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jae W. Lee
-  program_chair:  Mary Lou Soffa, Ayal Zaks
-
+  program_chair: Mary Lou Soffa, Ayal Zaks
+  series_link: https://2026.cgo.org/
 - name: CGO
   description: IEEE/ACM International Symposium on Code Generation and Optimization
   year: 2020
   link: https://cgo-conference.github.io/cgo2020/
-  deadline: "2020-09-06"
-  abstract_deadline: "2020-08-30"
-  notification_date: "2020-10-22"
-  date: "2020-02-22"
+  deadline: '2020-09-06'
+  abstract_deadline: '2020-08-30'
+  notification_date: '2020-10-22'
+  date: '2020-02-22'
   place: San Diego, CA
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jason Mars, Lingjia Tang
   program_chair: Jingling Xue, Peng Wu
-  
+  series_link: https://2026.cgo.org/
 - name: CGO
   description: IEEE/ACM International Symposium on Code Generation and Optimization
   year: 2019
   link: https://cgo.org/cgo2019/
-  deadline: "2018-09-07"
-  abstract_deadline: "2018-08-31"
-  notification_date: "2018-10-30"
-  date: "2019-02-16"
+  deadline: '2018-09-07'
+  abstract_deadline: '2018-08-31'
+  notification_date: '2018-10-30'
+  date: '2019-02-16'
   place: Washington, DC
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Mahmut Taylan Kandemir
   program_chair: Alexandra Jimborean, Tipp Moseley
-  
+  series_link: https://2026.cgo.org/
 - name: CGO
   description: IEEE/ACM International Symposium on Code Generation and Optimization
   year: 2018
   link: https://cgo.org/cgo2018/
-  deadline: "2017-09-15"
-  abstract_deadline: "2017-09-08"
-  notification_date: "2017-10-31"
-  date: "2018-02-24"
+  deadline: '2017-09-15'
+  abstract_deadline: '2017-09-08'
+  notification_date: '2017-10-31'
+  date: '2018-02-24'
   place: Vienna, Austria
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jens Knoop, Markus Schordan
   program_chair: Teresa Johnson, Michael O'Boyle
-
+  series_link: https://2026.cgo.org/
 - name: CGO
   description: IEEE/ACM International Symposium on Code Generation and Optimization
   year: 2017
   link: https://cgo.org/cgo2017/
-  deadline: "2016-09-13"
-  abstract_deadline: "2016-09-02"
-  notification_date: "2016-10-25"
-  date: "2017-02-04"
+  deadline: '2016-09-13'
+  abstract_deadline: '2016-09-02'
+  notification_date: '2016-10-25'
+  date: '2017-02-04'
   place: Austin, TX
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Vijay Janapa Reddi
   program_chair: Aaron Smith, Lingjia Tang
-
+  series_link: https://2026.cgo.org/
 - name: CGO
   description: IEEE/ACM International Symposium on Code Generation and Optimization
   year: 2016
   link: https://cgo.org/cgo2016/
-  deadline: "2015-09-18"
-  abstract_deadline: "2015-09-12"
-  notification_date: "2015-11-08"
-  date: "2016-03-12"
+  deadline: '2015-09-18'
+  abstract_deadline: '2015-09-12'
+  notification_date: '2015-11-08'
+  date: '2016-03-12'
   place: Barcelona, Spain
-  acceptance_rate: 
-  num_submission: 
+  acceptance_rate: null
+  num_submission: null
   general_chair: Bjoern Franke
   program_chair: Youfeng Wu, Fabrice Rastello
-
+  series_link: https://2026.cgo.org/
 - name: CGO
   description: IEEE/ACM International Symposium on Code Generation and Optimization
   year: 2015
   link: https://cgo.org/cgo2015/
-  deadline: "2014-09-12"
-  abstract_deadline: "2014-09-05"
-  notification_date: "2014-10-01"
-  date: "2015-02-09"
+  deadline: '2014-09-12'
+  abstract_deadline: '2014-09-05'
+  notification_date: '2014-10-01'
+  date: '2015-02-09'
   place: San Francisco, CA
-  acceptance_rate: 
-  num_submission: 
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Natalie Enright Jerger
-
-# Interdisciplinary Areas
-
-## Comp. bio & bioinformatics
-
+  series_link: https://2026.cgo.org/
 - name: ISMB
   description: Intelligent Systems for Molecular Biology
   year: 2024
   link: https://www.iscb.org/ismb2024/home
-  deadline: "2024-04-22"
-  abstract_deadline: "2024-04-19"
-  notification_date: "2024-05-13"
-  date: "2024-07-12"
+  deadline: '2024-04-22'
+  abstract_deadline: '2024-04-19'
+  notification_date: '2024-05-13'
+  date: '2024-07-12'
   place: Montreal, Canada
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Aïda Ouangraoua, Karin Verspoor
-
+  series_link: https://www.ismb.org/
 - name: ISMB/ECCB
-  description: Intelligent Systems for Molecular Biology / European Conference on Computational Biology
+  description: Intelligent Systems for Molecular Biology / European Conference on
+    Computational Biology
   year: 2023
   link: https://www.iscb.org/ismbeccb2023
-  deadline: "2023-05-04"
-  abstract_deadline: 
-  notification_date: "2023-05-25"
-  date: "2023-07-23"
+  deadline: '2023-05-04'
+  abstract_deadline: null
+  notification_date: '2023-05-25'
+  date: '2023-07-23'
   place: Lyon, France
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: ISMB
   description: Intelligent Systems for Molecular Biology
   year: 2022
   link: https://www.iscb.org/ismb2022
-  deadline: "2022-05-05"
-  abstract_deadline:
-  notification_date: "2022-05-26"
-  date: "2022-07-10"
+  deadline: '2022-05-05'
+  abstract_deadline: null
+  notification_date: '2022-05-26'
+  date: '2022-07-10'
   place: Madison, WI, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://www.ismb.org/
 - name: ISMB/ECCB
-  description: Intelligent Systems for Molecular Biology / European Conference on Computational Biology
+  description: Intelligent Systems for Molecular Biology / European Conference on
+    Computational Biology
   year: 2021
   link: https://www.iscb.org/ismbeccb2021
-  deadline: "2021-05-31"
-  abstract_deadline:
-  notification_date: "2021-06-03"
-  date: "2021-07-25"
+  deadline: '2021-05-31'
+  abstract_deadline: null
+  notification_date: '2021-06-03'
+  date: '2021-07-25'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: ISMB
   description: Intelligent Systems for Molecular Biology
   year: 2020
   link: https://www.iscb.org/ismb2020
-  deadline: "2020-05-07"
-  abstract_deadline:
-  notification_date: "2020-05-28"
-  date: "2020-07-13"
+  deadline: '2020-05-07'
+  abstract_deadline: null
+  notification_date: '2020-05-28'
+  date: '2020-07-13'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://www.ismb.org/
 - name: ISMB/ECCB
-  description: Intelligent Systems for Molecular Biology / European Conference on Computational Biology
+  description: Intelligent Systems for Molecular Biology / European Conference on
+    Computational Biology
   year: 2019
   link: https://www.iscb.org/ismbeccb2019
-  deadline: "2019-05-11"
-  abstract_deadline:
-  notification_date: "2019-05-30"
-  date: "2019-07-21"
+  deadline: '2019-05-11'
+  abstract_deadline: null
+  notification_date: '2019-05-30'
+  date: '2019-07-21'
   place: Basel, Switzerland
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: ISMB
   description: Intelligent Systems for Molecular Biology
   year: 2018
   link: https://www.iscb.org/ismb2018
-  deadline: "2018-05-10"
-  abstract_deadline:
-  notification_date: "2018-05-31"
-  date: "2018-07-06"
+  deadline: '2018-05-10'
+  abstract_deadline: null
+  notification_date: '2018-05-31'
+  date: '2018-07-06'
   place: Chicago, IL, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://www.ismb.org/
 - name: ISMB/ECCB
-  description: Intelligent Systems for Molecular Biology / European Conference on Computational Biology
+  description: Intelligent Systems for Molecular Biology / European Conference on
+    Computational Biology
   year: 2017
   link: https://www.iscb.org/ismbeccb2017
-  deadline: "2017-05-20"
-  abstract_deadline:
-  notification_date: "2017-05-31"
-  date: "2017-07-21"
+  deadline: '2017-05-20'
+  abstract_deadline: null
+  notification_date: '2017-05-31'
+  date: '2017-07-21'
   place: Prague, Czech Republic
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: ISMB
   description: Intelligent Systems for Molecular Biology
   year: 2016
   link: https://www.iscb.org/ismb2016
-  deadline: "2016-05-20"
-  abstract_deadline:
-  notification_date: "2016-05-31"
-  date: "2016-07-08"
+  deadline: '2016-05-20'
+  abstract_deadline: null
+  notification_date: '2016-05-31'
+  date: '2016-07-08'
   place: Orlando, FL, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://www.ismb.org/
 - name: ISMB/ECCB
-  description: Intelligent Systems for Molecular Biology / European Conference on Computational Biology
+  description: Intelligent Systems for Molecular Biology / European Conference on
+    Computational Biology
   year: 2015
   link: https://www.iscb.org/ismbeccb2015
-  deadline: "2015-06-05"
-  abstract_deadline:
-  notification_date: "2015-06-05"
-  date: "2015-07-10"
+  deadline: '2015-06-05'
+  abstract_deadline: null
+  notification_date: '2015-06-05'
+  date: '2015-07-10'
   place: Dublin, Ireland
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: RECOMB
   description: Research in Computational Molecular Biology
   year: 2024
   link: https://recomb.org/recomb2024/
-  deadline: "2023-11-03"
-  abstract_deadline: "2023-10-23"
-  notification_date: "2024-03-12"
-  date: "2024-04-29"
+  deadline: '2023-11-03'
+  abstract_deadline: '2023-10-23'
+  notification_date: '2024-03-12'
+  date: '2024-04-29'
   place: Cambridge, MA, USA
-  acceptance_rate:
-  num_submission:
-  general_chair: 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Jian Ma
-
+  series_link: https://recomb.org/
 - name: RECOMB
   description: Research in Computational Molecular Biology
   year: 2023
   link: https://recomb2023.bilkent.edu.tr/
-  deadline: "2022-10-14"
-  abstract_deadline: "2022-10-07"
-  notification_date: "2022-11-20"
-  date: "2023-04-16"
+  deadline: '2022-10-14'
+  abstract_deadline: '2022-10-07'
+  notification_date: '2022-11-20'
+  date: '2023-04-16'
   place: Istanbul, Turkey
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Haixu Tang
-
+  series_link: https://recomb.org/
 - name: RECOMB
   description: Research in Computational Molecular Biology
   year: 2022
   link: https://recomb.org/recomb2022/index.html
-  deadline: "2021-11-04"
-  abstract_deadline: "2021-11-04"
-  notification_date: "2022-04-01"
-  date: "2022-05-22"
+  deadline: '2021-11-04'
+  abstract_deadline: '2021-11-04'
+  notification_date: '2022-04-01'
+  date: '2022-05-22'
   place: La Jolla, CA, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Itsik Pe’er
-
+  series_link: https://recomb.org/
 - name: RECOMB
   description: Research in Computational Molecular Biology
   year: 2021
   link: https://recomb2021.org/
-  deadline: "2020-10-30"
-  abstract_deadline: 
-  notification_date: "2020-12-18"
-  date: "2021-04-19"
+  deadline: '2020-10-30'
+  abstract_deadline: null
+  notification_date: '2020-12-18'
+  date: '2021-04-19'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://recomb.org/
 - name: RECOMB
   description: Research in Computational Molecular Biology
   year: 2019
   link: https://recomb2019.org/
-  deadline: "2019-01-21"
-  abstract_deadline:
-  notification_date: "2019-02-21"
-  date: "2019-05-05"
+  deadline: '2019-01-21'
+  abstract_deadline: null
+  notification_date: '2019-02-21'
+  date: '2019-05-05'
   place: Washington, D.C., USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Lenore J. Cowen
-
+  series_link: https://recomb.org/
 - name: RECOMB
   description: Research in Computational Molecular Biology
   year: 2018
   link: https://recomb2018.fr
-  deadline: "2017-11-16"
-  abstract_deadline:
-  notification_date: "2017-12-21"
-  date: "2018-04-21"
+  deadline: '2017-11-16'
+  abstract_deadline: null
+  notification_date: '2017-12-21'
+  date: '2018-04-21'
   place: Paris, France
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Ben Raphael
-
+  series_link: https://recomb.org/
 - name: RECOMB
   description: Research in Computational Molecular Biology
   year: 2017
   link: https://cb.csail.mit.edu/recomb2017/
-  deadline: "2016-11-01"
-  abstract_deadline:
-  notification_date: "2016-12-16"
-  date: "2017-05-03"
+  deadline: '2016-11-01'
+  abstract_deadline: null
+  notification_date: '2016-12-16'
+  date: '2017-05-03'
   place: Hong Kong, China
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Cenk Sahinalp
-
+  series_link: https://recomb.org/
 - name: RECOMB
   description: Research in Computational Molecular Biology
   year: 2016
   link: https://recomb.org/recomb2016/index.html
-  deadline: "2015-10-26"
-  abstract_deadline:
-  notification_date: "2015-12-15"
-  date: "2016-04-16"
+  deadline: '2015-10-26'
+  abstract_deadline: null
+  notification_date: '2015-12-15'
+  date: '2016-04-16'
   place: Santa Monica, CA, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Mona Singh
-
+  series_link: https://recomb.org/
 - name: RECOMB
   description: Research in Computational Molecular Biology
   year: 2015
   link: https://recomb.org/recomb2015/
-  deadline: "2014-10-19"
-  abstract_deadline:
-  notification_date: "2014-12-15"
-  date: "2015-04-12"
+  deadline: '2014-10-19'
+  abstract_deadline: null
+  notification_date: '2014-12-15'
+  date: '2015-04-12'
   place: Warsaw, Poland
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Teresa Przytycka
-
-## Computer graphics
+  series_link: https://recomb.org/
 - name: Eurographics
   description: European Association for Computer Graphics
   year: 2026
   link: https://eg2026.github.io
-  deadline: "2025-09-26"
-  abstract_deadline: "2025-09-22"
-  notification_date: "2025-12-15"
-  date: "2026-05-04"
+  deadline: '2025-09-26'
+  abstract_deadline: '2025-09-22'
+  notification_date: '2025-12-15'
+  date: '2026-05-04'
   place: Aachen, Germany
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Leif Kobbelt, Shi-Min Hu
   program_chair: Belen Masia, Justus Thies
-
 - name: SIGGRAPH
   description: ACM Conference on Computer Graphics and Interactive Techniques
   year: 2025
   link: https://s2025.siggraph.org/
-  deadline: "2025-01-23"
-  abstract_deadline: "2025-01-16"
-  notification_date:
-  date: "2025-08-10"
+  deadline: '2025-01-23'
+  abstract_deadline: '2025-01-16'
+  notification_date: null
+  date: '2025-08-10'
   place: Vancouver, Canada
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Hao (Richard) Zhang
-
+  series_link: https://www.siggraph.org/
 - name: SIGGRAPH
   description: ACM Conference on Computer Graphics and Interactive Techniques
   year: 2024
   link: https://s2024.siggraph.org/
-  deadline: "2024-01-24"
-  abstract_deadline: "2024-01-23"
-  notification_date:
-  date: "2024-07-28"
+  deadline: '2024-01-24'
+  abstract_deadline: '2024-01-23'
+  notification_date: null
+  date: '2024-07-28'
   place: Denver, CO, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Andres Burbano
-
+  series_link: https://www.siggraph.org/
 - name: SIGGRAPH
   description: ACM Conference on Computer Graphics and Interactive Techniques
   year: 2023
   link: https://s2023.siggraph.org/
-  deadline: "2023-05-23"
-  abstract_deadline: "2023-05-16"
-  notification_date:
-  date: "2023-08-06"
+  deadline: '2023-05-23'
+  abstract_deadline: '2023-05-16'
+  notification_date: null
+  date: '2023-08-06'
   place: Los Angeles, CA, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Erik Brunvand
-
+  series_link: https://www.siggraph.org/
 - name: SIGGRAPH
   description: ACM Conference on Computer Graphics and Interactive Techniques
   year: 2022
   link: https://s2022.siggraph.org/
-  deadline: "2022-01-28"
-  abstract_deadline: "2022-01-27"
-  notification_date:
-  date: "2022-08-08"
+  deadline: '2022-01-28'
+  abstract_deadline: '2022-01-27'
+  notification_date: null
+  date: '2022-08-08'
   place: Vancouver, Canada
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Munkhtsetseg Nandigjav
-
+  series_link: https://www.siggraph.org/
 - name: SIGGRAPH
   description: ACM Conference on Computer Graphics and Interactive Techniques
   year: 2021
   link: https://s2021.siggraph.org/
-  deadline: "2021-05-21"
-  abstract_deadline: "2021-05-20"
-  notification_date:
-  date: "2021-08-09"
+  deadline: '2021-05-21'
+  abstract_deadline: '2021-05-20'
+  notification_date: null
+  date: '2021-08-09'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Pol Jeremias-Vila
-
+  series_link: https://www.siggraph.org/
 - name: SIGGRAPH
   description: ACM Conference on Computer Graphics and Interactive Techniques
   year: 2020
   link: https://s2020.siggraph.org/
-  deadline: "2020-01-22"
-  abstract_deadline: "2020-05-21"
-  notification_date:
-  date: "2020-08-17"
+  deadline: '2020-01-22'
+  abstract_deadline: '2020-05-21'
+  notification_date: null
+  date: '2020-08-17'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://www.siggraph.org/
 - name: SIGGRAPH
   description: ACM Conference on Computer Graphics and Interactive Techniques
   year: 2019
   link: https://s2019.siggraph.org/
-  deadline: "2019-01-20"
-  abstract_deadline: "2019-05-19"
-  notification_date:
-  date: "2019-07-28"
+  deadline: '2019-01-20'
+  abstract_deadline: '2019-05-19'
+  notification_date: null
+  date: '2019-07-28'
   place: Los Angeles, CA, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Mikki Rose
-
+  series_link: https://www.siggraph.org/
 - name: SIGGRAPH
   description: ACM Conference on Computer Graphics and Interactive Techniques
   year: 2018
   link: https://s2018.siggraph.org/
-  deadline: "2018-06-06"
-  abstract_deadline: "2018-06-05"
-  notification_date:
-  date: "2018-08-12"
+  deadline: '2018-06-06'
+  abstract_deadline: '2018-06-05'
+  notification_date: null
+  date: '2018-08-12'
   place: Vancouver, Canada
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Roy C. Anthony
-
+  series_link: https://www.siggraph.org/
 - name: SIGGRAPH
   description: ACM Conference on Computer Graphics and Interactive Techniques
   year: 2017
   link: https://s2017.siggraph.org/
-  deadline: "2017-01-15"
-  abstract_deadline: "2017-01-14"
-  notification_date:
-  date: "2017-07-30"
+  deadline: '2017-01-15'
+  abstract_deadline: '2017-01-14'
+  notification_date: null
+  date: '2017-07-30'
   place: Los Angeles, CA, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Jerome Solomon
-
+  series_link: https://www.siggraph.org/
 - name: SIGGRAPH
   description: ACM Conference on Computer Graphics and Interactive Techniques
   year: 2016
   link: https://s2016.siggraph.org/
-  deadline: "2016-01-18"
-  abstract_deadline: "2016-01-17"
-  notification_date:
-  date: "2016-07-24"
+  deadline: '2016-01-18'
+  abstract_deadline: '2016-01-17'
+  notification_date: null
+  date: '2016-07-24'
   place: Anaheim, CA, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Mona Kasra
-
+  series_link: https://www.siggraph.org/
 - name: SIGGRAPH Asia
-  description: ACM SIGGRAPH Conference and Exhibition on Computer Graphics and Interactive Techniques in Asia
+  description: ACM SIGGRAPH Conference and Exhibition on Computer Graphics and Interactive
+    Techniques in Asia
   year: 2025
   link: https://asia.siggraph.org/2025/
-  deadline: "2025-05-23"
-  abstract_deadline: "2025-05-16"
-  notification_date: "2025-08-10"
-  date: "2025-12-15"
+  deadline: '2025-05-23'
+  abstract_deadline: '2025-05-16'
+  notification_date: '2025-08-10'
+  date: '2025-12-15'
   place: Hong Kong
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Taku Komura
   program_chair: Michael Wimmer
-
+  series_link: https://asia.siggraph.org/2025/
 - name: SIGGRAPH Asia
-  description: ACM SIGGRAPH Conference and Exhibition on Computer Graphics and Interactive Techniques in Asia
+  description: ACM SIGGRAPH Conference and Exhibition on Computer Graphics and Interactive
+    Techniques in Asia
   year: 2024
   link: https://asia.siggraph.org/2024/
-  deadline: "2024-05-19"
-  abstract_deadline: "2024-05-12"
-  notification_date:
-  date: "2024-12-03"
+  deadline: '2024-05-19'
+  abstract_deadline: '2024-05-12'
+  notification_date: null
+  date: '2024-12-03'
   place: Tokyo, Japan
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Takeo Igarashi
-
+  series_link: https://asia.siggraph.org/2025/
 - name: SIGGRAPH Asia
-  description: ACM SIGGRAPH Conference and Exhibition on Computer Graphics and Interactive Techniques in Asia
+  description: ACM SIGGRAPH Conference and Exhibition on Computer Graphics and Interactive
+    Techniques in Asia
   year: 2023
   link: https://asia.siggraph.org/2023/
-  deadline: "2023-05-24"
-  abstract_deadline: "2023-05-16"
-  notification_date:
-  date: "2023-12-12"
+  deadline: '2023-05-24'
+  abstract_deadline: '2023-05-16'
+  notification_date: null
+  date: '2023-12-12'
   place: Sydney, Australia
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: June Kim
-
+  series_link: https://asia.siggraph.org/2025/
 - name: SIGGRAPH Asia
-  description: ACM SIGGRAPH Conference and Exhibition on Computer Graphics and Interactive Techniques in Asia
+  description: ACM SIGGRAPH Conference and Exhibition on Computer Graphics and Interactive
+    Techniques in Asia
   year: 2022
   link: https://sa2022.siggraph.org/
-  deadline: "2022-05-20"
-  abstract_deadline: "2022-05-19"
-  notification_date:
-  date: "2022-12-06"
+  deadline: '2022-05-20'
+  abstract_deadline: '2022-05-19'
+  notification_date: null
+  date: '2022-12-06'
   place: Daegu, South Korea
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Soon Ki Jung
-
+  series_link: https://asia.siggraph.org/2025/
 - name: SIGGRAPH Asia
-  description: ACM SIGGRAPH Conference and Exhibition on Computer Graphics and Interactive Techniques in Asia
+  description: ACM SIGGRAPH Conference and Exhibition on Computer Graphics and Interactive
+    Techniques in Asia
   year: 2021
   link: https://sa2021.siggraph.org/
-  deadline: "2021-05-22"
-  abstract_deadline: "2021-05-20"
-  notification_date:
-  date: "2021-12-14"
+  deadline: '2021-05-22'
+  abstract_deadline: '2021-05-20'
+  notification_date: null
+  date: '2021-12-14'
   place: Tokyo, Japan
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Shuzo John Shiota
-
+  series_link: https://asia.siggraph.org/2025/
 - name: SIGGRAPH Asia
-  description: ACM SIGGRAPH Conference and Exhibition on Computer Graphics and Interactive Techniques in Asia
+  description: ACM SIGGRAPH Conference and Exhibition on Computer Graphics and Interactive
+    Techniques in Asia
   year: 2020
   link: https://sa2020.siggraph.org/
-  deadline: "2020-05-22"
-  abstract_deadline: "2020-05-21"
-  notification_date: "2020-08-01"
-  date: "2020-12-04"
+  deadline: '2020-05-22'
+  abstract_deadline: '2020-05-21'
+  notification_date: '2020-08-01'
+  date: '2020-12-04'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Jinny HyeJin Choo
-
+  series_link: https://asia.siggraph.org/2025/
 - name: SIGGRAPH Asia
-  description: ACM SIGGRAPH Conference and Exhibition on Computer Graphics and Interactive Techniques in Asia
+  description: ACM SIGGRAPH Conference and Exhibition on Computer Graphics and Interactive
+    Techniques in Asia
   year: 2019
   link: https://sa2019.siggraph.org/
-  deadline: "2019-05-20"
-  abstract_deadline: "2019-05-19"
-  notification_date:
-  date: "2019-11-17"
+  deadline: '2019-05-20'
+  abstract_deadline: '2019-05-19'
+  notification_date: null
+  date: '2019-11-17'
   place: Brisbane, Australia
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Tomasz Bednarz
-
+  series_link: https://asia.siggraph.org/2025/
 - name: SIGGRAPH Asia
-  description: ACM SIGGRAPH Conference and Exhibition on Computer Graphics and Interactive Techniques in Asia
+  description: ACM SIGGRAPH Conference and Exhibition on Computer Graphics and Interactive
+    Techniques in Asia
   year: 2018
   link: https://sa2018.siggraph.org/
-  deadline: "2018-06-05"
-  abstract_deadline: "2018-06-04"
-  notification_date:
-  date: "2018-12-04"
+  deadline: '2018-06-05'
+  abstract_deadline: '2018-06-04'
+  notification_date: null
+  date: '2018-12-04'
   place: Tokyo, Japan
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Ken Anjyo
-
+  series_link: https://asia.siggraph.org/2025/
 - name: SIGGRAPH Asia
-  description: ACM SIGGRAPH Conference and Exhibition on Computer Graphics and Interactive Techniques in Asia
+  description: ACM SIGGRAPH Conference and Exhibition on Computer Graphics and Interactive
+    Techniques in Asia
   year: 2017
   link: https://sa2017.siggraph.org/
-  deadline: "2017-05-23"
-  abstract_deadline: "2017-05-22"
-  notification_date: 
-  date: "2017-11-27"
+  deadline: '2017-05-23'
+  abstract_deadline: '2017-05-22'
+  notification_date: null
+  date: '2017-11-27'
   place: Bangkok, Thailand
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: SUrapong Lertsithichai
-
+  series_link: https://asia.siggraph.org/2025/
 - name: SIGGRAPH Asia
-  description: ACM SIGGRAPH Conference and Exhibition on Computer Graphics and Interactive Techniques in Asia
+  description: ACM SIGGRAPH Conference and Exhibition on Computer Graphics and Interactive
+    Techniques in Asia
   year: 2016
   link: https://sa2016.siggraph.org/
-  deadline: "2016-05-17"
-  abstract_deadline: "2016-05-16"
-  notification_date:
-  date: "2016-12-05"
+  deadline: '2016-05-17'
+  abstract_deadline: '2016-05-16'
+  notification_date: null
+  date: '2016-12-05'
   place: Macao, China
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
-## Computer science education
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://asia.siggraph.org/2025/
 - name: SIGCSE TS
   description: ACM Technical Symposium on Computer Science Education
   year: 2025
   link: https://sigcse2025.sigcse.org/
-  deadline: "2024-07-21"
-  abstract_deadline: "2024-07-14"
-  notification_date: "2024-09-30"
-  date: "2025-02-26"
+  deadline: '2024-07-21'
+  abstract_deadline: '2024-07-14'
+  notification_date: '2024-09-30'
+  date: '2025-02-26'
   place: Pittsburgh, PA, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Samuel A. Rebelsky, Libby Shoop, James Prather
-
 - name: SIGCSE TS
   description: ACM Technical Symposium on Computer Science Education
   year: 2024
   link: https://sigcse2024.sigcse.org/
-  deadline: "2023-08-18"
-  abstract_deadline: "2023-08-11"
-  notification_date: "2023-10-02"
-  date: "2024-03-20"
+  deadline: '2023-08-18'
+  abstract_deadline: '2023-08-11'
+  notification_date: '2023-10-02'
+  date: '2024-03-20'
   place: Portland, OR, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Lina battestilli, Samuel A. Rebelsky, Libby Shoop
-
 - name: SIGCSE TS
   description: ACM Technical Symposium on Computer Science Education
   year: 2023
   link: https://sigcse2023.sigcse.org/
-  deadline: "2022-08-19"
-  abstract_deadline: "2022-08-12"
-  notification_date: "2022-10-03"
-  date: "2023-03-15"
+  deadline: '2022-08-19'
+  abstract_deadline: '2022-08-12'
+  notification_date: '2022-10-03'
+  date: '2023-03-15'
   place: Toronto, ON, Canada
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Lina Battestilli, Brian Dorn, Leen-Kiat Soh
-
 - name: SIGCSE TS
   description: ACM Technical Symposium on Computer Science Education
   year: 2022
   link: https://sigcse2022.sigcse.org/
-  deadline: "2021-08-13"
-  abstract_deadline: "2021-08-06"
-  notification_date: "2021-09-27"
-  date: "2022-03-02"
+  deadline: '2021-08-13'
+  abstract_deadline: '2021-08-06'
+  notification_date: '2021-09-27'
+  date: '2022-03-02'
   place: Providence, RI, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Brian Dorn, Leen-Kiat Soh, Judithe Sheard
-
 - name: SIGCSE TS
   description: ACM Technical Symposium on Computer Science Education
   year: 2021
   link: https://sigcse2021.sigcse.org/
-  deadline: "2020-08-28"
-  abstract_deadline: "2020-08-21"
-  notification_date: "2020-10-09"
-  date: "2021-03-13"
+  deadline: '2020-08-28'
+  abstract_deadline: '2020-08-21'
+  notification_date: '2020-10-09'
+  date: '2021-03-13'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Pam Cutter, Alvaro Monge, Judithe Sheard
-
 - name: SIGCSE TS
   description: ACM Technical Symposium on Computer Science Education
   year: 2020
   link: https://sigcse2020.sigcse.org/
-  deadline: "2019-08-30"
-  abstract_deadline: "2019-08-23"
-  notification_date: 
-  date: "2020-03-11"
+  deadline: '2019-08-30'
+  abstract_deadline: '2019-08-23'
+  notification_date: null
+  date: '2020-03-11'
   place: Portland, OR, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Sarah Heckman, Pam Cutter, Alvaro Monge
-
 - name: SIGCSE TS
   description: ACM Technical Symposium on Computer Science Education
   year: 2019
   link: https://sigcse2019.sigcse.org/
-  deadline: "2018-08-31"
-  abstract_deadline: "2018-08-24"
-  notification_date:
-  date: "2019-02-27"
+  deadline: '2018-08-31'
+  abstract_deadline: '2018-08-24'
+  notification_date: null
+  date: '2019-02-27'
   place: Minneapolis, MN, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Sarah Heckman, Jian Zhang
-
 - name: SIGCSE TS
   description: ACM Technical Symposium on Computer Science Education
   year: 2018
   link: https://sigcse2018.sigcse.org/
-  deadline: "2017-09-01"
-  abstract_deadline: "2017-08-25"
-  notification_date: "2017-10-07"
-  date: "2018-02-21"
+  deadline: '2017-09-01'
+  abstract_deadline: '2017-08-25'
+  notification_date: '2017-10-07'
+  date: '2018-02-21'
   place: Baltimore, MD, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Elizabeth K. Hawthorne, Manuel Pérez-Quiñones
-
 - name: SIGCSE TS
   description: ACM Technical Symposium on Computer Science Education
   year: 2017
   link: https://sigcse2017.sigcse.org/
-  deadline: "2016-08-26"
-  abstract_deadline:
-  notification_date: "2016-10-14"
-  date: "2017-03-08"
+  deadline: '2016-08-26'
+  abstract_deadline: null
+  notification_date: '2016-10-14'
+  date: '2017-03-08'
   place: Seattle, WA, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Tiffany Barnes, Daniel Garcia
-
 - name: SIGCSE TS
   description: ACM Technical Symposium on Computer Science Education
   year: 2016
   link: https://sigcse2016.sigcse.org/
-  deadline: "2015-08-28"
-  abstract_deadline:
-  notification_date: "2015-10-12"
-  date: "2016-03-02"
+  deadline: '2015-08-28'
+  abstract_deadline: null
+  notification_date: '2015-10-12'
+  date: '2016-03-02'
   place: Memphis, TN, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Michael E. Caspersen, Stephen Edwards
-
-## Economics & computation
-
 - name: EC
   description: ACM Conference on Economics and Computation
   year: 2025
@@ -10594,745 +10279,713 @@
   deadline: 2025-02-10
   abstract_deadline: 2025-02-03
   notification_date: 2025-05-17
-  date: "2025-07-07"
+  date: '2025-07-07'
   place: Stanford, CA, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Ilya Segal
   program_chair: Itai Ashlagi,  Aaron Roth
-
 - name: EC
   description: ACM Conference on Economics and Computation
   year: 2024
   link: https://ec24.sigecom.org
-  deadline: "2024-02-12"
-  abstract_deadline: "2024-02-05"
-  notification_date: "2024-05-18"
-  date: "2024-07-08"
+  deadline: '2024-02-12'
+  abstract_deadline: '2024-02-05'
+  notification_date: '2024-05-18'
+  date: '2024-07-08'
   place: New Haven, CT, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Dirk Bergemann
   program_chair: Daniela Saban, Robert Kleinberg
-
 - name: EC
   description: ACM Conference on Economics and Computation
   year: 2023
   link: https://ec23.sigecom.org
-  deadline: "2023-01-27"
-  abstract_deadline: "2023-01-20"
-  notification_date: "2023-03-06"
-  date: "2023-07-09"
+  deadline: '2023-01-27'
+  abstract_deadline: '2023-01-20'
+  notification_date: '2023-03-06'
+  date: '2023-07-09'
   place: London, UK
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Kevin Leyton-Brown
   program_chair: Jason Hartline, Larry Samuelson
-
 - name: EC
   description: ACM Conference on Economics and Computation
   year: 2022
   link: https://ec22.sigecom.org/index.html
-  deadline: "2022-02-10"
-  abstract_deadline:
-  notification_date: "2022-05-08"
-  date: "2022-07-11"
+  deadline: '2022-02-10'
+  abstract_deadline: null
+  notification_date: '2022-05-08'
+  date: '2022-07-11'
   place: Boulder, CO, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: David M. Pennock
   program_chair: Sven Seuken, Ilya Segal
-
 - name: EC
   description: ACM Conference on Economics and Computation
   year: 2021
   link: https://ec21.sigecom.org
-  deadline: "2021-02-12"
-  abstract_deadline: "2021-02-10"
-  notification_date: "2021-05-07"
-  date: "2021-07-19"
+  deadline: '2021-02-12'
+  abstract_deadline: '2021-02-10'
+  notification_date: '2021-05-07'
+  date: '2021-07-19'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Péter Biró, Eric Sodomka
   program_chair: Hu Fu, Annie Liang
-
 - name: EC
   description: ACM Conference on Economics and Computation
   year: 2020
   link: https://ec20.sigecom.org/index.html
-  deadline: "2020-02-12"
-  abstract_deadline:
-  notification_date: "2020-05-06"
-  date: "2020-07-13"
+  deadline: '2020-02-12'
+  abstract_deadline: null
+  notification_date: '2020-05-06'
+  date: '2020-07-13'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Péter Biró, Jason Hartline
-  program_chair: Michael Ostrovsky, Ariel Procaccia 
-
+  program_chair: Michael Ostrovsky, Ariel Procaccia
 - name: EC
   description: ACM Conference on Economics and Computation
   year: 2019
   link: https://www.sigecom.org/ec19/
-  deadline: "2019-03-01"
-  abstract_deadline:
-  notification_date: "2019-04-26"
-  date: "2019-06-24"
+  deadline: '2019-03-01'
+  abstract_deadline: null
+  notification_date: '2019-04-26'
+  date: '2019-06-24'
   place: Phoenix, AZ, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Anna Karlin
   program_chair: Nicole Immorlica, Ramesh Johari
-
 - name: EC
   description: ACM Conference on Economics and Computation
   year: 2018
   link: https://www.sigecom.org/ec18/
-  deadline: "2018-02-15"
-  abstract_deadline:
-  notification_date: "2018-04-20"
-  date: "2018-06-18"
+  deadline: '2018-02-15'
+  abstract_deadline: null
+  notification_date: '2018-04-20'
+  date: '2018-06-18'
   place: Ithaca, NY, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Eva Tardos
   program_chair: Edith Elkind, Rakesh Vohra
-
 - name: EC
   description: ACM Conference on Economics and Computation
   year: 2017
   link: https://www.sigecom.org/ec17/
-  deadline: "2017-02-13"
-  abstract_deadline: "2017-02-06"
-  notification_date:  "2017-04-20"
-  date: "2017-06-26"
+  deadline: '2017-02-13'
+  abstract_deadline: '2017-02-06'
+  notification_date: '2017-04-20'
+  date: '2017-06-26'
   place: Cambridge, MA, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Constantinos Daskalakis
   program_chair: Moshe Babaioff, Hervé Moulin
-
 - name: EC
   description: ACM Conference on Economics and Computation
   year: 2016
   link: https://www.sigecom.org/ec16/
-  deadline: "2016-02-23"
-  abstract_deadline:
-  notification_date: "2016-05-10"
-  date: "2016-07-24"
+  deadline: '2016-02-23'
+  abstract_deadline: null
+  notification_date: '2016-05-10'
+  date: '2016-07-24'
   place: Maastricht, Netherlands
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Vincent Conitzer
   program_chair: Dirk Bergemann, Yiling Chen
-
 - name: WINE
   description: International Conference on Web and Internet Economics
   year: 2023
   link: https://wine2023.shanghaitech.edu.cn
-  deadline: "2023-07-07"
-  abstract_deadline: 
-  notification_date: "2023-09-08"
-  date: "2023-12-04"
+  deadline: '2023-07-07'
+  abstract_deadline: null
+  notification_date: '2023-09-08'
+  date: '2023-12-04'
   place: Shanghai, China
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Shouyang Wang, Jingyi Yu
   program_chair: Jugal Garg, Max Klimm
-
 - name: WINE
   description: International Conference on Web and Internet Economics
   year: 2022
   link: https://link.springer.com/book/10.1007/978-3-031-20459-2
-  deadline: "2022-07-07"
-  abstract_deadline:
-  notification_date: "2022-09-07"
-  date: "2022-12-12"
+  deadline: '2022-07-07'
+  abstract_deadline: null
+  notification_date: '2022-09-07'
+  date: '2022-12-12'
   place: Troy, NY, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: WINE
   description: International Conference on Web and Internet Economics
   year: 2021
   link: https://hpi.de/wine2021/program/#content
-  deadline: "2021-07-12"
-  abstract_deadline:
-  notification_date: "2021-09-08"
-  date: "2021-12-14"
+  deadline: '2021-07-12'
+  abstract_deadline: null
+  notification_date: '2021-09-08'
+  date: '2021-12-14'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Ágnes Cseh, Pascal Lenzner
   program_chair: Michal Feldman, Hu Fu, Inbal Talgam-Cohen
-
 - name: WINE
   description: International Conference on Web and Internet Economics
   year: 2020
   link: https://link.springer.com/book/10.1007/978-3-030-64946-3
-  deadline: "2020-07-12"
-  abstract_deadline: 
-  notification_date: "2020-09-07"
-  date: "2020-12-07"
+  deadline: '2020-07-12'
+  abstract_deadline: null
+  notification_date: '2020-09-07'
+  date: '2020-12-07'
   place: Beijing, China
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: WINE
   description: International Conference on Web and Internet Economics
   year: 2019
   link: https://wine2019.cs.columbia.edu
-  deadline:
-  abstract_deadline:
-  notification_date:
-  date: "2019-12-10"
+  deadline: null
+  abstract_deadline: null
+  notification_date: null
+  date: '2019-12-10'
   place: New York, NY, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Paul Goldberg
   program_chair: Ioannis Caragiannis, Vahab Mirrokni, Evdokia Nikolova
-
 - name: WINE
   description: International Conference on Web and Internet Economics
   year: 2018
   link: https://www.cs.ox.ac.uk/conferences/wine2018/#:~:text=The%20Conference%20on%20Web%20and,Anne's%20College.
-  deadline: "2018-07-27"
-  abstract_deadline:
-  notification_date: "2018-09-24"
-  date: "2018-12-15"
+  deadline: '2018-07-27'
+  abstract_deadline: null
+  notification_date: '2018-09-24'
+  date: '2018-12-15'
   place: Oxford, UK
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Paul Goldberg
   program_chair: Giorgos Christodoulou, Tobias Harks
-
 - name: WINE
   description: International Conference on Web and Internet Economics
   year: 2017
   link: https://gtl.csa.iisc.ac.in/wine2017/
-  deadline: "2017-08-02"
-  abstract_deadline:
-  notification_date: "2017-09-25"
-  date: "2017-12-17"
+  deadline: '2017-08-02'
+  abstract_deadline: null
+  notification_date: '2017-09-25'
+  date: '2017-12-17'
   place: Bangalore, India
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Y. Narahari, Arunava Sen
   program_chair: Nikhil Devanur, Pinyan Lu
-
 - name: WINE
   description: International Conference on Web and Internet Economics
   year: 2016
   link: https://cs.mcgill.ca/~wine2016/
-  deadline: "2016-07-29"
-  abstract_deadline:
-  notification_date: "2016-09-26"
-  date: "2016-12-11"
+  deadline: '2016-07-29'
+  abstract_deadline: null
+  notification_date: '2016-09-26'
+  date: '2016-12-11'
   place: Montreal, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Yang Cai, Adrian Vetta
   program_chair: Yang Cai, Adrian Vetta
-
 - name: WINE
   description: International Conference on Web and Internet Economics
   year: 2015
   link: https://link.springer.com/book/10.1007/978-3-662-48995-6
-  deadline: "2015-07-24"
-  abstract_deadline:
-  notification_date: "2015-09-18"
-  date: "2015-12-09"
+  deadline: '2015-07-24'
+  abstract_deadline: null
+  notification_date: '2015-09-18'
+  date: '2015-12-09'
   place: Cambridge, MA, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Guido Schäfer
   program_chair: Vangelis Markakis, Guido Schäfer
-
-
-## Human-computer interaction
 - name: CHI
   description: ACM Conference on Human Factors in Computing Systems
   year: 2026
   link: https://chi2026.acm.org
-  deadline: "2025-09-11"
-  abstract_deadline: "2025-09-04"
-  notification_date: "2026-01-15"
-  date: "2026-04-13"
+  deadline: '2025-09-11'
+  abstract_deadline: '2025-09-04'
+  notification_date: '2026-01-15'
+  date: '2026-04-13'
   place: Barcelona, Spain
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: David A. Shamma, Nuria Oliver
   program_chair: Alessandro Bozzon, Thomas Kosch, Vera Liao, Xiaojuan Ma
-
 - name: CHI
   description: ACM Conference on Human Factors in Computing Systems
   year: 2025
   link: https://chi2025.acm.org/
-  deadline: "2024-09-12"
-  abstract_deadline: "2024-09-05"
-  notification_date: "2025-01-16"
-  date: "2025-04-26"
+  deadline: '2024-09-12'
+  abstract_deadline: '2024-09-05'
+  notification_date: '2025-01-16'
+  date: '2025-04-26'
   place: Yokohama, Japan
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Naomi Yamashita, Vanessa Evers
   program_chair: Koji Yatani, Sharon Ding
-
 - name: CHI
   description: ACM Conference on Human Factors in Computing Systems
   year: 2024
   link: https://chi2024.acm.org/
-  deadline: "2023-09-14"
-  abstract_deadline: "2023-09-07"
-  notification_date: "2024-01-19"
-  date: "2024-05-11"
+  deadline: '2023-09-14'
+  abstract_deadline: '2023-09-07'
+  notification_date: '2024-01-19'
+  date: '2024-05-11'
   place: Honolulu, Hawaiʻi, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Florian ‘Floyd’ Mueller, Penny Kyburz
   program_chair: Julie R. Williamson, Corina Sas
-
 - name: CHI
   description: ACM Conference on Human Factors in Computing Systems
   year: 2023
   link: https://chi2023.acm.org/
-  deadline: "2022-09-15"
-  abstract_deadline: "2022-09-08"
-  notification_date: "2023-01-13"
-  date: "2023-04-23"
+  deadline: '2022-09-15'
+  abstract_deadline: '2022-09-08'
+  notification_date: '2023-01-13'
+  date: '2023-04-23'
   place: Hamburg, Germany
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Albrecht Schmidt, Kaisa Väänänen
   program_chair: Tesh Goyal, Per Ola Kristensson, Anicia Peters
-
 - name: CHI
   description: ACM Conference on Human Factors in Computing Systems
   year: 2022
   link: https://chi2022.acm.org/
-  deadline: "2021-09-09"
-  abstract_deadline: "2021-09-02"
-  notification_date: "2021-11-18"
-  date: "2022-04-30"
+  deadline: '2021-09-09'
+  abstract_deadline: '2021-09-02'
+  notification_date: '2021-11-18'
+  date: '2022-04-30'
   place: New Orleans, LA, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Cliff Lampe, Simone Barbosa
   program_chair: David A. Shamma, Caroline Appert
-
 - name: CHI
   description: ACM Conference on Human Factors in Computing Systems
   year: 2021
   link: https://chi2021.acm.org/
-  deadline: "2021-02-17"
-  abstract_deadline: 
-  notification_date: "2021-04-21"
-  date: "2021-05-08"
+  deadline: '2021-02-17'
+  abstract_deadline: null
+  notification_date: '2021-04-21'
+  date: '2021-05-08'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: CHI
   description: ACM Conference on Human Factors in Computing Systems
   year: 2020
   link: https://chi2020.acm.org/
-  deadline: "2019-09-20"
-  abstract_deadline: "2019-09-13"
-  notification_date: "2019-12-09"
-  date: "2020-04-25"
+  deadline: '2019-09-20'
+  abstract_deadline: '2019-09-13'
+  notification_date: '2019-12-09'
+  date: '2020-04-25'
   place: Honolulu, Hawaiʻi, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Regina Bernhaupt, Florian ‘Floyd’ Mueller
   program_chair: Joanna McGrenere, Andy Cockburn
-
 - name: CHI
   description: ACM Conference on Human Factors in Computing Systems
   year: 2019
   link: https://chi2019.acm.org/
-  deadline: "2018-09-21"
-  abstract_deadline: "2018-09-14"
-  notification_date: "2018-12-10"
-  date: "2019-05-04"
+  deadline: '2018-09-21'
+  abstract_deadline: '2018-09-14'
+  notification_date: '2018-12-10'
+  date: '2019-05-04'
   place: Glasgow, Scotland, UK
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Stephen Brewster, Geraldine Fitzpatrick
   program_chair: Anna Cox, Vassilis Kostakos
-
 - name: CHI
   description: ACM Conference on Human Factors in Computing Systems
   year: 2018
   link: https://chi2018.acm.org/
-  deadline: "2017-09-19"
-  abstract_deadline: "2017-09-14"
-  notification_date: "2017-12-11"
-  date: "2018-04-21"
+  deadline: '2017-09-19'
+  abstract_deadline: '2017-09-14'
+  notification_date: '2017-12-11'
+  date: '2018-04-21'
   place: Montreal, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Regan Mandryk, Mark Hancock
   program_chair: Mark Perry, Anna Cox
-
 - name: CHI
   description: ACM Conference on Human Factors in Computing Systems
   year: 2017
   link: https://chi2017.acm.org/
-  deadline: "2016-09-21"
-  abstract_deadline: "2016-09-14"
-  notification_date: "2016-12-12"
-  date: "2017-05-06"
+  deadline: '2016-09-21'
+  abstract_deadline: '2016-09-14'
+  notification_date: '2016-12-12'
+  date: '2017-05-06'
   place: Denver, Colorado, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Gloria Mark, Susan Fussell,
   program_chair: M. C. Schraefel
-
 - name: CHI
   description: ACM Conference on Human Factors in Computing Systems
   year: 2016
   link: https://chi2016.acm.org/
-  deadline: "2015-09-25"
-  abstract_deadline:
-  notification_date: "2015-12-14"
-  date: "2016-05-07"
+  deadline: '2015-09-25'
+  abstract_deadline: null
+  notification_date: '2015-12-14'
+  date: '2016-05-07'
   place: San Jose, California, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jofish Kaye, Allison Druin
   program_chair: Cliff Lampe
-
 - name: UbiComp / ISWC
-  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing and International Symposium on Wearable Computers
+  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing
+    and International Symposium on Wearable Computers
   year: 2025
   link: https://www.ubicomp.org/ubicomp-iswc-2025/
-  deadline: "2025-05-25"
-  abstract_deadline:
-  notification_date: "2025-07-02"
-  date: "2025-10-14"
+  deadline: '2025-05-25'
+  abstract_deadline: null
+  notification_date: '2025-07-02'
+  date: '2025-10-14'
   place: Espoo, Finland
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Michael Beigl, Giulio Jacucci, Stephan Sigg, Yu Xiao
   program_chair: Jakob Bardram, Chenren Xu, Eirini Eleni Tsiropoulou
-
 - name: UbiComp / ISWC
-  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing and International Symposium on Wearable Computers
+  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing
+    and International Symposium on Wearable Computers
   year: 2024
   link: https://www.ubicomp.org/ubicomp-iswc-2024/
-  deadline: "2024-05-26"
-  abstract_deadline:
-  notification_date: "2024-06-28"
-  date: "2024-10-05"
+  deadline: '2024-05-26'
+  abstract_deadline: null
+  notification_date: '2024-06-28'
+  date: '2024-10-05'
   place: Melbourne, Australia
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Vassilis Kostakos, Judy Kay, Thuong Hoang
   program_chair: Sarah Clinch, Cheng Zhang, Jorge Goncalves
-
 - name: UbiComp / ISWC
-  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing and International Symposium on Wearable Computers
+  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing
+    and International Symposium on Wearable Computers
   year: 2023
   link: https://www.ubicomp.org/ubicomp-iswc-2023/
-  deadline: "2023-05-26"
-  abstract_deadline:
-  notification_date: "2023-07-03"
-  date: "2023-10-08"
+  deadline: '2023-05-26'
+  abstract_deadline: null
+  notification_date: '2023-07-03'
+  date: '2023-10-08'
   place: Cancún, Mexico
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Monica Tentori, Nadir Weibel, Kristof Van Laerhoven
   program_chair: Edison Thomaz, Silvia Santini, Judy Kay
-
 - name: UbiComp / ISWC
-  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing and International Symposium on Wearable Computers
+  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing
+    and International Symposium on Wearable Computers
   year: 2022
   link: https://ubicomp.org/ubicomp2022/
-  deadline: "2022-08-05"
-  abstract_deadline:
-  notification_date: "2022-08-21"
-  date: "2022-09-11"
+  deadline: '2022-08-05'
+  abstract_deadline: null
+  notification_date: '2022-08-21'
+  date: '2022-09-11'
   place: Cambridge, United Kingdom
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Robert K. Harle, Thomas Plötz
   program_chair: Christian Holz, JeongGil Ko, Lena Mamykina
-
 - name: UbiComp / ISWC
-  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing and International Symposium on Wearable Computers
+  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing
+    and International Symposium on Wearable Computers
   year: 2021
   link: https://ubicomp.org/ubicomp2021/
-  deadline: "2021-06-18"
-  abstract_deadline:
-  notification_date: "2021-07-20"
-  date: "2021-09-21"
+  deadline: '2021-06-18'
+  abstract_deadline: null
+  notification_date: '2021-07-20'
+  date: '2021-09-21'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Afsaneh Doryab, Qin Lv, Michael Beigl
   program_chair: Christos Efstratiou, Uichin Lee
-
 - name: UbiComp / ISWC
-  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing and International Symposium on Wearable Computers
+  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing
+    and International Symposium on Wearable Computers
   year: 2020
   link: https://ubicomp.org/ubicomp2020/
-  deadline: "2019-02-15"
-  abstract_deadline:
-  notification_date:
-  date: "2020-09-12"
+  deadline: '2019-02-15'
+  abstract_deadline: null
+  notification_date: null
+  date: '2020-09-12'
   place: Virtual Conference
   note: Cycle 1/4
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Monica Tentori, Nadir Weibel, Kristof Van Laerhoven
   program_chair: Gregory Abowd, Flora Salim
-
 - name: UbiComp / ISWC
-  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing and International Symposium on Wearable Computers
+  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing
+    and International Symposium on Wearable Computers
   year: 2020
   link: https://ubicomp.org/ubicomp2020/
-  deadline: "2019-05-15"
-  abstract_deadline:
-  notification_date:
-  date: "2020-09-12"
+  deadline: '2019-05-15'
+  abstract_deadline: null
+  notification_date: null
+  date: '2020-09-12'
   place: Virtual Conference
   note: Cycle 2/4
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Monica Tentori, Nadir Weibel, Kristof Van Laerhoven
   program_chair: Gregory Abowd, Flora Salim
-
 - name: UbiComp / ISWC
-  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing and International Symposium on Wearable Computers
+  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing
+    and International Symposium on Wearable Computers
   year: 2020
   link: https://ubicomp.org/ubicomp2020/
-  deadline: "2019-08-15"
-  abstract_deadline:
-  notification_date:
-  date: "2020-09-12"
+  deadline: '2019-08-15'
+  abstract_deadline: null
+  notification_date: null
+  date: '2020-09-12'
   place: Virtual Conference
   note: Cycle 3/4
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Monica Tentori, Nadir Weibel, Kristof Van Laerhoven
   program_chair: Gregory Abowd, Flora Salim
-
 - name: UbiComp / ISWC
-  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing and International Symposium on Wearable Computers
+  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing
+    and International Symposium on Wearable Computers
   year: 2020
   link: https://ubicomp.org/ubicomp2020/
-  deadline: "2019-11-15"
-  abstract_deadline:
-  notification_date:
-  date: "2020-09-12"
+  deadline: '2019-11-15'
+  abstract_deadline: null
+  notification_date: null
+  date: '2020-09-12'
   place: Virtual Conference
   note: Cycle 4/4
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Monica Tentori, Nadir Weibel, Kristof Van Laerhoven
   program_chair: Gregory Abowd, Flora Salim
-
 - name: UbiComp / ISWC
-  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing and International Symposium on Wearable Computers
+  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing
+    and International Symposium on Wearable Computers
   year: 2019
   link: https://ubicomp.org/ubicomp2019/
-  deadline: "2018-08-15"
-  abstract_deadline:
-  notification_date:
-  date: "2019-09-09"
+  deadline: '2018-08-15'
+  abstract_deadline: null
+  notification_date: null
+  date: '2019-09-09'
   place: London, United Kingdom
   note: Cycle 1/4
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Robert Harle, Katayoun Farrahi, Nicholas Lane
   program_chair: Anind Dey, Mirco Musolesi, Lucy E. Dunne
-
 - name: UbiComp / ISWC
-  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing and International Symposium on Wearable Computers
+  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing
+    and International Symposium on Wearable Computers
   year: 2019
   link: https://ubicomp.org/ubicomp2019/
-  deadline: "2018-11-15"
-  abstract_deadline:
-  notification_date:
-  date: "2019-09-09"
+  deadline: '2018-11-15'
+  abstract_deadline: null
+  notification_date: null
+  date: '2019-09-09'
   place: London, United Kingdom
   note: Cycle 2/4
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Robert Harle, Katayoun Farrahi, Nicholas Lane
   program_chair: Anind Dey, Mirco Musolesi, Lucy E. Dunne
-
 - name: UbiComp / ISWC
-  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing and International Symposium on Wearable Computers
+  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing
+    and International Symposium on Wearable Computers
   year: 2019
   link: https://ubicomp.org/ubicomp2019/
-  deadline: "2019-02-15"
-  abstract_deadline:
-  notification_date:
-  date: "2019-09-09"
+  deadline: '2019-02-15'
+  abstract_deadline: null
+  notification_date: null
+  date: '2019-09-09'
   place: London, United Kingdom
   note: Cycle 3/4
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Robert Harle, Katayoun Farrahi, Nicholas Lane
   program_chair: Anind Dey, Mirco Musolesi, Lucy E. Dunne
-
 - name: UbiComp / ISWC
-  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing and International Symposium on Wearable Computers
+  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing
+    and International Symposium on Wearable Computers
   year: 2019
   link: https://ubicomp.org/ubicomp2019/
-  deadline: "2019-05-15"
-  abstract_deadline:
-  notification_date:
-  date: "2019-09-09"
+  deadline: '2019-05-15'
+  abstract_deadline: null
+  notification_date: null
+  date: '2019-09-09'
   place: London, United Kingdom
   note: Cycle 4/4
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Robert Harle, Katayoun Farrahi, Nicholas Lane
   program_chair: Anind Dey, Mirco Musolesi, Lucy E. Dunne
-
 - name: UbiComp / ISWC
-  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing and International Symposium on Wearable Computers
+  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing
+    and International Symposium on Wearable Computers
   year: 2018
   link: https://ubicomp.org/ubicomp2018/
-  deadline: "2017-08-15"
-  abstract_deadline:
-  notification_date:
-  date: "2018-10-08"
+  deadline: '2017-08-15'
+  abstract_deadline: null
+  notification_date: null
+  date: '2018-10-08'
   place: Singapore
   note: Cycle 1/4
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Rajesh K. Balan, Youngki Lee, Kai Kunze
   program_chair: Cecilia Mascolo, Kamin Whitehouse, Youngki Lee
-
 - name: UbiComp / ISWC
-  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing and International Symposium on Wearable Computers
+  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing
+    and International Symposium on Wearable Computers
   year: 2018
   link: https://ubicomp.org/ubicomp2018/
-  deadline: "2017-11-15"
-  abstract_deadline:
-  notification_date:
-  date: "2018-10-08"
+  deadline: '2017-11-15'
+  abstract_deadline: null
+  notification_date: null
+  date: '2018-10-08'
   place: Singapore
   note: Cycle 2/4
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Rajesh K. Balan, Youngki Lee, Kai Kunze
   program_chair: Cecilia Mascolo, Kamin Whitehouse, Youngki Lee
-
 - name: UbiComp / ISWC
-  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing and International Symposium on Wearable Computers
+  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing
+    and International Symposium on Wearable Computers
   year: 2018
   link: https://ubicomp.org/ubicomp2018/
-  deadline: "2018-02-15"
-  abstract_deadline:
-  notification_date:
-  date: "2018-10-08"
+  deadline: '2018-02-15'
+  abstract_deadline: null
+  notification_date: null
+  date: '2018-10-08'
   place: Singapore
   note: Cycle 3/4
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Rajesh K. Balan, Youngki Lee, Kai Kunze
   program_chair: Cecilia Mascolo, Kamin Whitehouse, Youngki Lee
-
 - name: UbiComp / ISWC
-  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing and International Symposium on Wearable Computers
+  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing
+    and International Symposium on Wearable Computers
   year: 2018
   link: https://ubicomp.org/ubicomp2018/
-  deadline: "2018-05-15"
-  abstract_deadline:
-  notification_date:
-  date: "2018-10-08"
+  deadline: '2018-05-15'
+  abstract_deadline: null
+  notification_date: null
+  date: '2018-10-08'
   place: Singapore
   note: Cycle 4/4
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Rajesh K. Balan, Youngki Lee, Kai Kunze
   program_chair: Cecilia Mascolo, Kamin Whitehouse, Youngki Lee
-
 - name: UbiComp / ISWC
-  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing and International Symposium on Wearable Computers
+  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing
+    and International Symposium on Wearable Computers
   year: 2017
   link: https://ubicomp.org/ubicomp2017/
-  deadline: "2016-08-15"
-  abstract_deadline:
-  notification_date:
-  date: "2017-09-11"
+  deadline: '2016-08-15'
+  abstract_deadline: null
+  notification_date: null
+  date: '2017-09-11'
   place: Maui, Hawaii, USA
   note: Cycle 1/4
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Seungyon "Claire" Lee, Leila Takayama, Khai Truong
-  program_chair:
-
+  program_chair: null
 - name: UbiComp / ISWC
-  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing and International Symposium on Wearable Computers
+  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing
+    and International Symposium on Wearable Computers
   year: 2017
   link: https://ubicomp.org/ubicomp2017/
-  deadline: "2016-11-15"
-  abstract_deadline:
-  notification_date:
-  date: "2017-09-11"
+  deadline: '2016-11-15'
+  abstract_deadline: null
+  notification_date: null
+  date: '2017-09-11'
   place: Maui, Hawaii, USA
   note: Cycle 2/4
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Seungyon "Claire" Lee, Leila Takayama, Khai Truong
-  program_chair:
-
+  program_chair: null
 - name: UbiComp / ISWC
-  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing and International Symposium on Wearable Computers
+  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing
+    and International Symposium on Wearable Computers
   year: 2017
   link: https://ubicomp.org/ubicomp2017/
-  deadline: "2017-02-15"
-  abstract_deadline:
-  notification_date:
-  date: "2017-09-11"
+  deadline: '2017-02-15'
+  abstract_deadline: null
+  notification_date: null
+  date: '2017-09-11'
   place: Maui, Hawaii, USA
   note: Cycle 3/4
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Seungyon "Claire" Lee, Leila Takayama, Khai Truong
-  program_chair:
-
+  program_chair: null
 - name: UbiComp / ISWC
-  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing and International Symposium on Wearable Computers
+  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing
+    and International Symposium on Wearable Computers
   year: 2017
   link: https://ubicomp.org/ubicomp2017/
-  deadline: "2017-05-15"
-  abstract_deadline:
-  notification_date:
-  date: "2017-09-11"
+  deadline: '2017-05-15'
+  abstract_deadline: null
+  notification_date: null
+  date: '2017-09-11'
   place: Maui, Hawaii, USA
   note: Cycle 4/4
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Seungyon "Claire" Lee, Leila Takayama, Khai Truong
-  program_chair:
-
+  program_chair: null
 - name: UbiComp / ISWC
-  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing and International Symposium on Wearable Computers
+  description: ACM International Joint Conference on Pervasive and Ubiquitous Computing
+    and International Symposium on Wearable Computers
   year: 2016
   link: https://iswc.net/iswc16/index.html
-  deadline: "2016-04-23"
-  abstract_deadline:
-  notification_date: "2016-06-17"
-  date: "2016-09-12"
+  deadline: '2016-04-23'
+  abstract_deadline: null
+  notification_date: '2016-06-17'
+  date: '2016-09-12'
   place: Heidelberg, Germany
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Michael Beigl, Paul Lukowicz
   program_chair: Ulf Blanke, Kai Kunze, Seungyon Claire Lee
-
 - name: UIST
   description: ACM Symposium on User Interface Software and Technology
   year: 2025
@@ -11340,856 +10993,837 @@
   deadline: 2025-04-09
   abstract_deadline: 2025-04-02
   notification_date: 2025-07-05
-  date: "2025-09-28"
+  date: '2025-09-28'
   place: Busan, South Korea
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Andrea Bianchi, Wendy Mackay, Shengdong Zhao, Elena Glassman
-
+  series_link: https://uist.acm.org/2026/
 - name: UIST
   description: ACM Symposium on User Interface Software and Technology
   year: 2024
   link: https://uist.acm.org/2024/
-  deadline: "2024-04-03"
-  abstract_deadline: "2024-03-27"
-  notification_date: "2024-06-29"
-  date: "2024-10-13"
+  deadline: '2024-04-03'
+  abstract_deadline: '2024-03-27'
+  notification_date: '2024-06-29'
+  date: '2024-10-13'
   place: Pittsburgh, PA, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Alexandra Ion, Pedro Lopes
-
+  series_link: https://uist.acm.org/2026/
 - name: UIST
   description: ACM Symposium on User Interface Software and Technology
   year: 2023
   link: https://uist.acm.org/2023/
-  deadline: "2023-04-05"
-  abstract_deadline: "2023-03-30"
-  notification_date: "2023-06-24"
-  date: "2023-10-29"
+  deadline: '2023-04-05'
+  abstract_deadline: '2023-03-30'
+  notification_date: '2023-06-24'
+  date: '2023-10-29'
   place: San Francisco, CA, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Jurgen Steimle, Natalie Henry Riche
-
+  series_link: https://uist.acm.org/2026/
 - name: UIST
   description: ACM Symposium on User Interface Software and Technology
   year: 2022
   link: https://uist.acm.org/uist2022/
-  deadline: "2022-04-07"
-  abstract_deadline: "2022-03-31"
-  notification_date: "2022-06-25"
-  date: "2022-10-29"
+  deadline: '2022-04-07'
+  abstract_deadline: '2022-03-31'
+  notification_date: '2022-06-25'
+  date: '2022-10-29'
   place: Bend, OR, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Eytan Adar, Vidya Setlur
-
+  series_link: https://uist.acm.org/2026/
 - name: UIST
   description: ACM Symposium on User Interface Software and Technology
   year: 2021
   link: https://uist.acm.org/uist2021/
-  deadline: "2021-04-07"
-  abstract_deadline: "2021-03-31"
-  notification_date: "2021-06-25"
-  date: "2021-10-10"
+  deadline: '2021-04-07'
+  abstract_deadline: '2021-03-31'
+  notification_date: '2021-06-25'
+  date: '2021-10-10'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Ranjitha Kumar, Michael Nebeling
-
+  series_link: https://uist.acm.org/2026/
 - name: UIST
   description: ACM Symposium on User Interface Software and Technology
   year: 2020
   link: https://uist.acm.org/uist2020/
-  deadline: "2020-05-06"
-  abstract_deadline: "2020-04-20"
-  notification_date: "2020-07-21"
-  date: "2020-10-20"
+  deadline: '2020-05-06'
+  abstract_deadline: '2020-04-20'
+  notification_date: '2020-07-21'
+  date: '2020-10-20'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Fanny Chevalier, Stefanie Mueller
-
+  series_link: https://uist.acm.org/2026/
 - name: UIST
   description: ACM Symposium on User Interface Software and Technology
   year: 2019
   link: https://uist.acm.org/uist2019/
-  deadline: "2019-04-05"
-  abstract_deadline:
-  notification_date: "2019-07-22"
-  date: "2019-10-20"
+  deadline: '2019-04-05'
+  abstract_deadline: null
+  notification_date: '2019-07-22'
+  date: '2019-10-20'
   place: New Orleans, LA, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Michael Bernstein, Katharina Reinecke
-
+  series_link: https://uist.acm.org/2026/
 - name: UIST
   description: ACM Symposium on User Interface Software and Technology
   year: 2018
   link: https://uist.acm.org/uist2018/
-  deadline: "2018-04-05"
-  abstract_deadline:
-  notification_date: "2018-07-23"
-  date: "2018-10-14"
+  deadline: '2018-04-05'
+  abstract_deadline: null
+  notification_date: '2018-07-23'
+  date: '2018-10-14'
   place: Berlin, Germany
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Andy Wilson
-
+  series_link: https://uist.acm.org/2026/
 - name: UIST
   description: ACM Symposium on User Interface Software and Technology
   year: 2017
   link: https://uist.acm.org/uist2017/
-  deadline: "2017-04-04"
-  abstract_deadline:
-  notification_date: "2017-07-21"
-  date: "2017-10-22"
+  deadline: '2017-04-04'
+  abstract_deadline: null
+  notification_date: '2017-07-21'
+  date: '2017-10-22'
   place: Quebec City, Canada
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Jennifer Mankoff, Chris Harrison
-
+  series_link: https://uist.acm.org/2026/
 - name: UIST
   description: ACM Symposium on User Interface Software and Technology
   year: 2016
   link: https://uist.acm.org/uist2016/
-  deadline: "2016-04-13"
-  abstract_deadline:
-  notification_date: "2016-08-02"
-  date: "2016-10-16"
+  deadline: '2016-04-13'
+  abstract_deadline: null
+  notification_date: '2016-08-02'
+  date: '2016-10-16'
   place: Tokyo, Japan
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Daniel Avrahami, Jacob O. Wobbrock
-
-## Robotics
-
+  series_link: https://uist.acm.org/2026/
 - name: ICRA
   description: IEEE International Conference on Robotics and Automation
   year: 2025
   link: https://2025.ieee-icra.org/
-  deadline: "2024-09-16"
-  abstract_deadline:
-  notification_date:
-  date: "2025-05-19"
+  deadline: '2024-09-16'
+  abstract_deadline: null
+  notification_date: null
+  date: '2025-05-19'
   place: Atlanta, GA, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Seth Hutchinson, Nancy Amato
-  program_chair:
-
+  program_chair: null
+  series_link: https://icra.org/
 - name: ICRA
   description: IEEE International Conference on Robotics and Automation
   year: 2024
   link: https://2024.ieee-icra.org/
-  deadline: "2023-09-15"
-  abstract_deadline:
-  notification_date:
-  date: "2024-05-13"
+  deadline: '2023-09-15'
+  abstract_deadline: null
+  notification_date: null
+  date: '2024-05-13'
   place: Yokohama, Japan
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Zhidong Wang, Seth Hutchinson, Antonio Bicchi
   program_chair: Yasuhisa Hasegawa, Kanako Harada, Torsten Kroeger, Nancy Amato
-
+  series_link: https://icra.org/
 - name: ICRA
   description: IEEE International Conference on Robotics and Automation
   year: 2023
   link: https://www.icra2023.org/
-  deadline: "2022-03-06"
-  abstract_deadline:
-  notification_date:
-  date: "2023-05-29"
+  deadline: '2022-03-06'
+  abstract_deadline: null
+  notification_date: null
+  date: '2023-05-29'
   place: London, United Kingdom
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Kaspar Althoefer
   program_chair: Seth Hutchinson
-
+  series_link: https://icra.org/
 - name: ICRA
   description: IEEE International Conference on Robotics and Automation
   year: 2022
   link: https://www.icra2022.org/
-  deadline: "2021-09-15"
-  abstract_deadline:
-  notification_date: "2022-01-31"
-  date: "2022-05-23"
+  deadline: '2021-09-15'
+  abstract_deadline: null
+  notification_date: '2022-01-31'
+  date: '2022-05-23'
   place: Philadelphia, PA, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Hadas Kress-Gazit
-
+  series_link: https://icra.org/
 - name: ICRA
   description: IEEE International Conference on Robotics and Automation
   year: 2021
   link: https://www.ieee-ras.org/about-ras/ras-calendar/event/1920-icra-2021
-  deadline:
-  abstract_deadline:
-  notification_date:
-  date: "2021-05-30"
+  deadline: null
+  abstract_deadline: null
+  notification_date: null
+  date: '2021-05-30'
   place: Xi'an, China
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
+  series_link: https://icra.org/
 - name: ICRA
   description: IEEE International Conference on Robotics and Automation
   year: 2020
   link: https://www.icra2020.org/
-  deadline: "2019-09-15"
-  abstract_deadline:
-  notification_date: "2020-01-31"
-  date: "2020-05-31"
+  deadline: '2019-09-15'
+  abstract_deadline: null
+  notification_date: '2020-01-31'
+  date: '2020-05-31'
   place: Paris, France
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Stéphane Régnier, Roland Siegwart
   program_chair: Wolfram Burgard, Nancy Amato, Fuhimito Arai, François Chaumette
-
+  series_link: https://icra.org/
 - name: ICRA
   description: IEEE International Conference on Robotics and Automation
   year: 2019
   link: https://www.icra2019.org/
-  deadline: "2018-09-15"
-  abstract_deadline:
-  notification_date:  
-  date: "2019-05-20"
+  deadline: '2018-09-15'
+  abstract_deadline: null
+  notification_date: null
+  date: '2019-05-20'
   place: Montreal, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Gregory Dudek
   program_chair: Jaydev P. Desai
-
+  series_link: https://icra.org/
 - name: ICRA
   description: IEEE International Conference on Robotics and Automation
   year: 2018
   link: https://www.ieee-ras.org/component/rseventspro/event/570-icra-2018-ieee-international-conference-on-robotics-and-automation
-  deadline: "2017-09-15"
-  abstract_deadline:
-  notification_date: "2018-01-26"
-  date: "2018-05-21"
+  deadline: '2017-09-15'
+  abstract_deadline: null
+  notification_date: '2018-01-26'
+  date: '2018-05-21'
   place: Brisbane, Australia
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Alex Zelinsky, Frank Park
-  program_chair: Peter Corke, Nancy M. Amato, Megan Emmons, Yoshihiko Nakamura, Markus Vincze
-
+  program_chair: Peter Corke, Nancy M. Amato, Megan Emmons, Yoshihiko Nakamura, Markus
+    Vincze
+  series_link: https://icra.org/
 - name: ICRA
   description: IEEE International Conference on Robotics and Automation
   year: 2017
   link: https://www.ieee-ras.org/component/rseventspro/event/569-icra-2017-ieee-international-conference-on-robotics-and-automation
-  deadline: "2016-09-15"
-  abstract_deadline:
-  notification_date: "2017-01-15"
-  date: "2017-05-29"
+  deadline: '2016-09-15'
+  abstract_deadline: null
+  notification_date: '2017-01-15'
+  date: '2017-05-29'
   place: Singapore
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: I-Ming Chen, Marcelo Ang
-  program_chair: Yoshihiko Nakamura, Antonio Bicchi, Chien Chern Cheah, Henrik Christensen, Frank Park
-
+  program_chair: Yoshihiko Nakamura, Antonio Bicchi, Chien Chern Cheah, Henrik Christensen,
+    Frank Park
+  series_link: https://icra.org/
 - name: ICRA
   description: IEEE International Conference on Robotics and Automation
   year: 2016
   link: https://www.ieee-ras.org/component/rseventspro/event/419-icra-2016-ieee-international-conference-on-robotics-and-automation
-  deadline: "2015-09-15"
-  abstract_deadline:
-  notification_date: "2016-01-15"
-  date: "2016-05-16"
+  deadline: '2015-09-15'
+  abstract_deadline: null
+  notification_date: '2016-01-15'
+  date: '2016-05-16'
   place: Stockholm, Sweden
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Danica Kragic, Tamim Asfour, Magnus Egerstedt, David Hsu
-  program_chair: Antonio Bicchi, Alessandro De Luca, Alin Albu-Schäffer, Seth Hutchinson, Satoshi Tadokoro  
-
+  program_chair: Antonio Bicchi, Alessandro De Luca, Alin Albu-Schäffer, Seth Hutchinson,
+    Satoshi Tadokoro
+  series_link: https://icra.org/
 - name: IROS
   description: IEEE/RSJ International Conference on Intelligent Robots and Systems
   year: 2025
   link: https://www.iros25.org/
-  deadline: "2025-03-02"
-  abstract_deadline:
-  notification_date:
-  date: "2025-10-19"
+  deadline: '2025-03-02'
+  abstract_deadline: null
+  notification_date: null
+  date: '2025-10-19'
   place: Hangzhou, China
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Hesheng Wang, Paul Y.Oh, Tetsuya Ogata, Torsten Kröger
   program_chair: Yi Guo, Jindong Tan, Qing Shi, Dongjun Lee, Elena De Momi
-
 - name: IROS
   description: IEEE/RSJ International Conference on Intelligent Robots and Systems
   year: 2024
   link: https://iros2024-abudhabi.org/
-  deadline: "2024-03-15"
-  abstract_deadline:
-  notification_date: "2024-06-31"
-  date: "2024-10-14"
+  deadline: '2024-03-15'
+  abstract_deadline: null
+  notification_date: '2024-06-31'
+  date: '2024-10-14'
   place: Abu Dhabi, UAE
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jorge Dias, Cecilia Laschi
-  program_chair: Arif Sultan Al Hammadi, Lakmal Serneviratne, Satoshi Tadokoro, Anthony A. Maciejewski, Kostas J. Kyriakopoulos
-
+  program_chair: Arif Sultan Al Hammadi, Lakmal Serneviratne, Satoshi Tadokoro, Anthony
+    A. Maciejewski, Kostas J. Kyriakopoulos
 - name: IROS
   description: IEEE/RSJ International Conference on Intelligent Robots and Systems
   year: 2023
   link: https://ieee-iros.org/
-  deadline: "2023-03-01"
-  abstract_deadline:
-  notification_date: "2023-07-31"
-  date: "2023-10-01"
+  deadline: '2023-03-01'
+  abstract_deadline: null
+  notification_date: '2023-07-31'
+  date: '2023-10-01'
   place: Detroit, Michigan, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Jim Schmiedeler
   program_chair: Bobby Gregg
-
 - name: IROS
   description: IEEE/RSJ International Conference on Intelligent Robots and Systems
   year: 2022
   link: https://iros2022.org/
-  deadline: "2022-03-01"
-  abstract_deadline:
-  notification_date: "2022-06-30"
-  date: "2022-10-23"
+  deadline: '2022-03-01'
+  abstract_deadline: null
+  notification_date: '2022-06-30'
+  date: '2022-10-23'
   place: Kyoto, Japan
-  acceptance_rate:
-  num_submission:
-  general_chair: Shugen Ma, 
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Shugen Ma,
   program_chair: Yasushi Nakauchi
-
 - name: IROS
   description: IEEE/RSJ International Conference on Intelligent Robots and Systems
   year: 2021
   link: https://www.aconf.org/conf_178649.2021_IEEE/RSJ_International_Conference_on_Intelligent_Robots_and_Systems.html
-  deadline: "2021-03-01"
-  abstract_deadline:
-  notification_date: "2021-06-30"
-  date: "2021-09-27"
+  deadline: '2021-03-01'
+  abstract_deadline: null
+  notification_date: '2021-06-30'
+  date: '2021-09-27'
   place: Prague, Czech Republic
-  acceptance_rate:
-  num_submission:
-  general_chair: Libor Přeučil 
-  program_chair: Robert Babuška 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Libor Přeučil
+  program_chair: Robert Babuška
 - name: IROS
   description: IEEE/RSJ International Conference on Intelligent Robots and Systems
   year: 2020
   link: https://ewh.ieee.org/soc/ras/conf/financiallycosponsored/IROS/IROS2020/www.iros2020.org/1general/committees.html
-  deadline: "2020-03-01"
-  abstract_deadline: 
-  notification_date: "2020-06-30"
-  date: "2020-10-25"
+  deadline: '2020-03-01'
+  abstract_deadline: null
+  notification_date: '2020-06-30'
+  date: '2020-10-25'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Paul Oh
   program_chair: Marcia O’Malley
-
 - name: IROS
   description: IEEE/RSJ International Conference on Intelligent Robots and Systems
   year: 2019
   link: https://www.iros2019.org/
-  deadline: "2019-03-01"
-  abstract_deadline:
-  notification_date: "2019-06-30"
-  date: "2019-11-04"
+  deadline: '2019-03-01'
+  abstract_deadline: null
+  notification_date: '2019-06-30'
+  date: '2019-11-04'
   place: Macau, China
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Dong Sun
   program_chair: Fumihito Arai
-
 - name: IROS
   description: IEEE/RSJ International Conference on Intelligent Robots and Systems
   year: 2018
   link: https://www.iros2018.org/
-  deadline: "2018-03-01"
-  abstract_deadline:
-  notification_date: "2018-06-29"
-  date: "2018-10-01"
+  deadline: '2018-03-01'
+  abstract_deadline: null
+  notification_date: '2018-06-29'
+  date: '2018-10-01'
   place: Madrid, Spain
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Carlos Balaguer
   program_chair: Cecilia Laschi
-
 - name: IROS
   description: IEEE/RSJ International Conference on Intelligent Robots and Systems
   year: 2017
   link: https://ewh.ieee.org/conf/iros/2017/iros2017.org/index.html
-  deadline: "2017-03-01"
-  abstract_deadline:
-  notification_date: "2017-06-15"
-  date: "2017-09-24"
+  deadline: '2017-03-01'
+  abstract_deadline: null
+  notification_date: '2017-06-15'
+  date: '2017-09-24'
   place: Vancouver, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Hong Zhang
   program_chair: Richard Vaughan
-
 - name: IROS
   description: IEEE/RSJ International Conference on Intelligent Robots and Systems
   year: 2016
   link: https://www.ieee-ras.org/component/rseventspro/event/775-iros-2016-ieee-rsj-international-conference-on-intelligent-robots-and-systems
-  deadline: "2016-03-01"
-  abstract_deadline:
-  notification_date: "2016-07-01"
-  date: "2016-10-09"
+  deadline: '2016-03-01'
+  abstract_deadline: null
+  notification_date: '2016-07-01'
+  date: '2016-10-09'
   place: Daejeon, South Korea
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Il Hong Suh
   program_chair: Dong-Soo Kwon
-
-
 - name: RSS
-  description: "Robotics: Science and Systems Conference"
+  description: 'Robotics: Science and Systems Conference'
   year: 2025
   link: https://roboticsconference.org/
-  deadline: "2025-01-24"
-  abstract_deadline: "2025-01-17"
-  notification_date: "2025-04-10"
-  date: "2025-06-21"
+  deadline: '2025-01-24'
+  abstract_deadline: '2025-01-17'
+  notification_date: '2025-04-10'
+  date: '2025-06-21'
   place: Los Angeles, California, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Dana Kulic, Gentiane Venture
   program_chair: Luca Carlone
-
 - name: RSS
-  description: "Robotics: Science and Systems Conference"
+  description: 'Robotics: Science and Systems Conference'
   year: 2024
   link: https://roboticsconference.org/2024/
-  deadline: "2024-02-02"
-  abstract_deadline:
-  notification_date: "2024-05-13"
-  date: "2024-07-15"
+  deadline: '2024-02-02'
+  abstract_deadline: null
+  notification_date: '2024-05-13'
+  date: '2024-07-15'
   place: Delft, Netherlands
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Kostas Bekris
   program_chair: Dana Kulic, Gentiane Venture
-
 - name: RSS
-  description: "Robotics: Science and Systems Conference"
+  description: 'Robotics: Science and Systems Conference'
   year: 2023
   link: https://roboticsconference.org/2023/
-  deadline: "2023-02-03"
-  abstract_deadline:
-  notification_date: "2023-04-22"
-  date: "2023-07-10"
+  deadline: '2023-02-03'
+  abstract_deadline: null
+  notification_date: '2023-04-22'
+  date: '2023-07-10'
   place: Daegu, South Korea
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Kris Hauser
   program_chair: Kostas E. Bekris
-
 - name: RSS
-  description: "Robotics: Science and Systems Conference"
+  description: 'Robotics: Science and Systems Conference'
   year: 2022
   link: https://roboticsconference.org/2022/
-  deadline: "2022-01-28"
-  abstract_deadline:
-  notification_date: "2022-04-15"
-  date: "2022-06-27"
+  deadline: '2022-01-28'
+  abstract_deadline: null
+  notification_date: '2022-04-15'
+  date: '2022-06-27'
   place: New York City, New York, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Dylan Shell
   program_chair: Kris Hauser
-
 - name: RSS
-  description: "Robotics: Science and Systems Conference"
+  description: 'Robotics: Science and Systems Conference'
   year: 2021
   link: https://roboticsconference.org/2021/
-  deadline: "2021-03-01"
-  abstract_deadline:
-  notification_date: "2021-05-10"
-  date: "2021-07-12"
+  deadline: '2021-03-01'
+  abstract_deadline: null
+  notification_date: '2021-05-10'
+  date: '2021-07-12'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Marc Toussaint
   program_chair: Dylan Shell
-
 - name: RSS
-  description: "Robotics: Science and Systems Conference"
+  description: 'Robotics: Science and Systems Conference'
   year: 2020
   link: https://roboticsconference.org/2020/
-  deadline: "2020-01-31"
-  abstract_deadline:
-  notification_date: "2020-05-01"
-  date: "2020-07-12"
+  deadline: '2020-01-31'
+  abstract_deadline: null
+  notification_date: '2020-05-01'
+  date: '2020-07-12'
   place: Corvallis, Oregon, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Antonio Bicchi
   program_chair: Marc Toussaint
-
 - name: RSS
-  description: "Robotics: Science and Systems Conference"
+  description: 'Robotics: Science and Systems Conference'
   year: 2019
   link: https://roboticsconference.org/2019/
-  deadline: "2019-02-01"
-  abstract_deadline:
-  notification_date: "2019-05-01"
-  date: "2019-06-22"
+  deadline: '2019-02-01'
+  abstract_deadline: null
+  notification_date: '2019-05-01'
+  date: '2019-06-22'
   place: Freiburg, Germany
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Hadas Kress-Gazit
   program_chair: Antonio Bicchi
-
 - name: RSS
-  description: "Robotics: Science and Systems Conference"
+  description: 'Robotics: Science and Systems Conference'
   year: 2018
   link: https://rislab.org/rss2018website/
-  deadline: "2018-02-01"
-  abstract_deadline:
-  notification_date: "2018-04-12"
-  date: "2018-06-26"
+  deadline: '2018-02-01'
+  abstract_deadline: null
+  notification_date: '2018-04-12'
+  date: '2018-06-26'
   place: Pittsburgh, Pennsylvania, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Siddhartha Srinivasa
   program_chair: Hadas Kress-Gazit
-
 - name: RSS
-  description: "Robotics: Science and Systems Conference"
+  description: 'Robotics: Science and Systems Conference'
   year: 2017
   link: https://roboticsconference.org/2017/
-  deadline: "2017-01-30"
-  abstract_deadline:
-  notification_date: "2017-04-30"
-  date: "2017-07-12"
+  deadline: '2017-01-30'
+  abstract_deadline: null
+  notification_date: '2017-04-30'
+  date: '2017-07-12'
   place: Cambridge, Massachusetts, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
-  program_chair:
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
+  program_chair: null
 - name: RSS
-  description: "Robotics: Science and Systems Conference"
+  description: 'Robotics: Science and Systems Conference'
   year: 2016
   link: https://roboticsconference.org/2016/
-  deadline: "2016-01-28"
-  abstract_deadline:
-  notification_date: "2016-04-22"
-  date: "2016-06-18"
+  deadline: '2016-01-28'
+  abstract_deadline: null
+  notification_date: '2016-04-22'
+  date: '2016-06-18'
   place: Ann Arbor, Michigan, USA
-  acceptance_rate:
-  num_submission:
-  general_chair:
+  acceptance_rate: null
+  num_submission: null
+  general_chair: null
   program_chair: Nancy M. Amato
-
-## Visualization 
-
 - name: VIS
   description: IEEE Visualization Conference
   year: 2025
   link: https://ieeevis.org/year/2025/welcome
-  deadline: "2025-03-31"
-  abstract_deadline: "2025-03-21"
-  notification_date: "2025-07-15"
-  date: "2025-11-02"
+  deadline: '2025-03-31'
+  abstract_deadline: '2025-03-21'
+  notification_date: '2025-07-15'
+  date: '2025-11-02'
   place: Vienna, Austria
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Johanna Schmidt, Eduard Gröller, Barbora Kozlíková, Krešimir Matković
-  program_chair: Alfie Abdul-Rahman, Tushar Athawale, Gautam Chaudhary, Michelle Dowling, Michael Oppermann
-
+  program_chair: Alfie Abdul-Rahman, Tushar Athawale, Gautam Chaudhary, Michelle Dowling,
+    Michael Oppermann
+  series_link: https://www.vis.org/
 - name: VIS
   description: IEEE Visualization Conference
   year: 2024
   link: https://ieeevis.org/year/2024/welcome
-  deadline: "2024-03-31"
-  abstract_deadline: "2024-03-21"
-  notification_date: "2024-07-15"
-  date: "2024-10-13"
+  deadline: '2024-03-31'
+  abstract_deadline: '2024-03-21'
+  notification_date: '2024-07-15'
+  date: '2024-10-13'
   place: Tampa Bay, Florida, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Paul Rosen, Kristin Potter, Remco Chang
   program_chair: Lane Harrison, Kate Isaacs, Michelle Dowling
-
+  series_link: https://www.vis.org/
 - name: VIS
   description: IEEE Visualization Conference
   year: 2023
   link: https://ieeevis.org/year/2023/welcome
-  deadline: "2023-03-31"
-  abstract_deadline: "2023-03-21"
-  notification_date: "2023-07-15"
-  date: "2023-10-22"
+  deadline: '2023-03-31'
+  abstract_deadline: '2023-03-21'
+  notification_date: '2023-07-15'
+  date: '2023-10-22'
   place: Melbourne, Australia
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Tim Dwyer, Sarah Goodwin, Michael Wybrow
   program_chair: Gautam Chaudhary, Joshua A. Levine, Lane Harrison, Kate Isaacs
-
+  series_link: https://www.vis.org/
 - name: VIS
   description: IEEE Visualization Conference
   year: 2022
   link: https://ieeevis.org/year/2022/welcome
-  deadline: "2022-03-31"
-  abstract_deadline: "2022-03-21"
-  notification_date: "2022-07-15"
-  date: "2022-10-16"
+  deadline: '2022-03-31'
+  abstract_deadline: '2022-03-21'
+  notification_date: '2022-07-15'
+  date: '2022-10-16'
   place: Oklahoma City, Oklahoma, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Danielle Szafir, David Ebert, Hendrik Strobelt
   program_chair: Gautam Chaudhary, Joshua A. Levine
-
+  series_link: https://www.vis.org/
 - name: VIS
   description: IEEE Visualization Conference
   year: 2021
   link: https://ieeevis.org/year/2021/welcome
-  deadline: "2021-03-31"
-  abstract_deadline: "2021-03-21"
-  notification_date: "2021-07-15"
-  date: "2021-10-24"
+  deadline: '2021-03-31'
+  abstract_deadline: '2021-03-21'
+  notification_date: '2021-07-15'
+  date: '2021-10-24'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Brian Summa, Luis Gustavo Nonato
   program_chair: Gautam Chaudhary, Joshua A. Levine
-
+  series_link: https://www.vis.org/
 - name: VIS
   description: IEEE Visualization Conference
   year: 2020
   link: https://ieeevis.org/year/2020/welcome
-  deadline: "2020-04-30"
-  abstract_deadline: "2020-04-20"
-  notification_date: "2020-08-14"
-  date: "2020-10-25"
+  deadline: '2020-04-30'
+  abstract_deadline: '2020-04-20'
+  notification_date: '2020-08-14'
+  date: '2020-10-25'
   place: Virtual Conference
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Valerio Pascucci, Mike Kirby
   program_chair: Gautam Chaudhary
-
+  series_link: https://www.vis.org/
 - name: VIS
   description: IEEE Visualization Conference
   year: 2019
   link: https://ieeevis.org/year/2019/welcome
-  deadline: "2019-03-31"
-  abstract_deadline: "2019-03-21"
-  notification_date: "2019-07-08"
-  date: "2019-10-20"
+  deadline: '2019-03-31'
+  abstract_deadline: '2019-03-21'
+  notification_date: '2019-07-08'
+  date: '2019-10-20'
   place: Vancouver, Canada
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Alex Endert, Brian Fisher, Wesley Willett
   program_chair: Gautam Chaudhary
-
+  series_link: https://www.vis.org/
 - name: VIS
   description: IEEE Visualization Conference
   year: 2018
   link: https://ieeevis.org/year/2018/welcome
-  deadline: "2018-03-31"
-  abstract_deadline: "2018-03-21"
-  notification_date: "2018-07-11"
-  date: "2018-10-21"
+  deadline: '2018-03-31'
+  abstract_deadline: '2018-03-21'
+  notification_date: '2018-07-11'
+  date: '2018-10-21'
   place: Berlin, Germany
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Holger Theisel
   program_chair: Gautam Chaudhary
-
+  series_link: https://www.vis.org/
 - name: VIS
   description: IEEE Visualization Conference
   year: 2017
   link: https://ieeevis.org/year/2017/welcome
-  deadline: "2017-03-31"
-  abstract_deadline: "2017-03-21"
-  notification_date: "2017-07-11"
-  date: "2017-10-01"
+  deadline: '2017-03-31'
+  abstract_deadline: '2017-03-21'
+  notification_date: '2017-07-11'
+  date: '2017-10-01'
   place: Phoenix, Arizona, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: James Ahrens
   program_chair: Gautam Chaudhary
-
+  series_link: https://www.vis.org/
 - name: VIS
   description: IEEE Visualization Conference
   year: 2016
   link: https://ieeevis.org/year/2016/info/vis-welcome/welcome
-  deadline: "2016-03-31"
-  abstract_deadline: "2016-03-21"
-  notification_date: "2016-07-11"
-  date: "2016-10-23"
+  deadline: '2016-03-31'
+  abstract_deadline: '2016-03-21'
+  notification_date: '2016-07-11'
+  date: '2016-10-23'
   place: Baltimore, Maryland, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Terry Yoo
   program_chair: James Ahrens, Gautam Chaudhary
-
+  series_link: https://www.vis.org/
 - name: VR
   description: IEEE Conference on Virtual Reality and 3D User Interfaces
   year: 2025
   link: https://ieeevr.org/2025/
-  deadline: "2024-09-18"
-  abstract_deadline: "2024-09-11"
-  notification_date: "2025-01-13"
-  date: "2025-03-08"
+  deadline: '2024-09-18'
+  abstract_deadline: '2024-09-11'
+  notification_date: '2025-01-13'
+  date: '2025-03-08'
   place: Saint-Malo, France
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Anatole Lécuyer, Ferran Argelaguet, Anne-Hélène Olivier
   program_chair: Daisuke Iwai, Tabitha Peck, Voicu Popescu, Luciana Nedel
-
+  series_link: https://www.vr.org/
 - name: VR
   description: IEEE Conference on Virtual Reality and 3D User Interfaces
   year: 2024
   link: https://ieeevr.org/2024/
-  deadline:
-  abstract_deadline:
-  notification_date:
-  date: "2024-03-16"
+  deadline: null
+  abstract_deadline: null
+  notification_date: null
+  date: '2024-03-16'
   place: Orlando, Florida, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Carolina Cruz-Neira, Greg Welch, Xubo Yang
   program_chair: Yuta Itoh, Tabitha Peck, Voicu Popescu, Stefanie Zollmann
-
+  series_link: https://www.vr.org/
 - name: VR
   description: IEEE Conference on Virtual Reality and 3D User Interfaces
   year: 2023
   link: https://ieeevr.org/2023/
-  deadline: "2022-10-14"
-  abstract_deadline: "2022-10-07"
-  notification_date: "2023-01-30"
-  date: "2023-03-25"
+  deadline: '2022-10-14'
+  abstract_deadline: '2022-10-07'
+  notification_date: '2023-01-30'
+  date: '2023-03-25'
   place: Shanghai, China
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Xubo Yang, Kun Zhou, Stephan Lukosch, Tobias Langlot
   program_chair: Bobby Bodenheimer, Voicu Popescu, John Quarles, Lili Wang
-
+  series_link: https://www.vr.org/
 - name: VR
   description: IEEE Conference on Virtual Reality and 3D User Interfaces
   year: 2022
   link: https://ieeevr.org/2022/
-  deadline: "2021-11-5"
-  abstract_deadline: "2021-11-01"
-  notification_date: "2021-12-22"
-  date: "2022-03-12"
+  deadline: 2021-11-5
+  abstract_deadline: '2021-11-01'
+  notification_date: '2021-12-22'
+  date: '2022-03-12'
   place: Christchurch, New Zealand
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Stephan Lukosch, Tobias Langlotz, Joaquim Jorge
-  program_chair:
-
+  program_chair: null
+  series_link: https://www.vr.org/
 - name: VR
   description: IEEE Conference on Virtual Reality and 3D User Interfaces
   year: 2021
   link: https://ieeevr.org/2021/
-  deadline: "2020-11-13"
-  abstract_deadline: "2020-11-06"
-  notification_date: "2021-01-13"
-  date: "2021-03-27"
+  deadline: '2020-11-13'
+  abstract_deadline: '2020-11-06'
+  notification_date: '2021-01-13'
+  date: '2021-03-27'
   place: Lisbon, Portugal
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Joaquim Jorge, Kyle Johnsen, J. Edward Swan II, Pedro Campos
-  program_chair:
-
+  program_chair: null
+  series_link: https://www.vr.org/
 - name: VR
   description: IEEE Conference on Virtual Reality and 3D User Interfaces
   year: 2020
   link: https://ieeevr.org/2020/
-  deadline: "2019-09-10"
-  abstract_deadline: "2019-09-03"
-  notification_date: "2019-11-09"
-  date: "2020-03-22"
+  deadline: '2019-09-10'
+  abstract_deadline: '2019-09-03'
+  notification_date: '2019-11-09'
+  date: '2020-03-22'
   place: Atlanta, Georgia, USA
-  acceptance_rate:
-  num_submission:
-  general_chair: Kyle Johnsen, Blair MacIntyre, J. Edward Swan II, Kiyoshi Kiyokawa 
-  program_chair: Maud Marchal, Joe Gabbard, Joaquim Jorge, Torsten Kuhlen, Anthony Steed 
-
+  acceptance_rate: null
+  num_submission: null
+  general_chair: Kyle Johnsen, Blair MacIntyre, J. Edward Swan II, Kiyoshi Kiyokawa
+  program_chair: Maud Marchal, Joe Gabbard, Joaquim Jorge, Torsten Kuhlen, Anthony
+    Steed
+  series_link: https://www.vr.org/
 - name: VR
   description: IEEE Conference on Virtual Reality and 3D User Interfaces
   year: 2019
   link: https://ieeevr.org/2019/
-  deadline: "2018-09-10"
-  abstract_deadline: "2018-09-03"
-  notification_date: "2018-11-15"
-  date: "2019-03-23"
+  deadline: '2018-09-10'
+  abstract_deadline: '2018-09-03'
+  notification_date: '2018-11-15'
+  date: '2019-03-23'
   place: Osaka, Japan
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Kiyoshi Kiyokawa, Hideyuki Ando, Betty Mohler
   program_chair: Bruce Thomas, Greg Welch, Torsten Kuhlen, Kyle Johnsen
-
+  series_link: https://www.vr.org/
 - name: VR
   description: IEEE Conference on Virtual Reality and 3D User Interfaces
   year: 2018
   link: https://ieeevr.org/2018/
-  deadline: "2017-09-11"
-  abstract_deadline: "2018-09-04"
-  notification_date: "2017-11-08"
-  date: "2018-03-18"
+  deadline: '2017-09-11'
+  abstract_deadline: '2018-09-04'
+  notification_date: '2017-11-08'
+  date: '2018-03-18'
   place: Reutlingen, Germany
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Betty Mohler, Torsten W. Kuhlen, Matthias Bues, Evan Suma Rosenberg
   program_chair: Kiyoshi Kiyokawa, Frank Steinicke, Bruce Thomas, Greg Welch
-
+  series_link: https://www.vr.org/
 - name: VR
   description: IEEE Conference on Virtual Reality and 3D User Interfaces
   year: 2017
   link: https://ieeevr.org/2017/
-  deadline: "2016-09-19"
-  abstract_deadline: "2016-09-12"
-  notification_date: "2016-11-22"
-  date: "2017-03-18"
+  deadline: '2016-09-19'
+  abstract_deadline: '2016-09-12'
+  notification_date: '2016-11-22'
+  date: '2017-03-18'
   place: Los Angeles, California, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Evan Suma Rosenberg, David Krum, Zachary Wartell
   program_chair: Betty Mohler, Sabarish Babu, Frank Steinicke, Victoria Interrante
-
+  series_link: https://www.vr.org/
 - name: VR
   description: IEEE Conference on Virtual Reality and 3D User Interfaces
   year: 2016
   link: https://ieeevr.org/2016/
-  deadline: "2015-09-21"
-  abstract_deadline: "2015-09-14"
-  notification_date: "2015-11-23"
-  date: "2016-03-19"
+  deadline: '2015-09-21'
+  abstract_deadline: '2015-09-14'
+  notification_date: '2015-11-23'
+  date: '2016-03-19'
   place: Greenville, South Carolina, USA
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Sabarish V. Babu, Sabine Coquillart, Larry F. Hodges, Zach Wartell
   program_chair: Tobias Höllerer, Vicki Interrante, Anatole Lécuyer, Evan Suma
-
+  series_link: https://www.vr.org/
 - name: VR
   description: IEEE Conference on Virtual Reality and 3D User Interfaces
   year: 2015
   link: https://ieeevr.org/2015/
-  deadline: "2014-09-18"
-  abstract_deadline: "2014-09-08"
-  notification_date: "2014-11-04"
-  date: "2015-03-23"
+  deadline: '2014-09-18'
+  abstract_deadline: '2014-09-08'
+  notification_date: '2014-11-04'
+  date: '2015-03-23'
   place: Arles, Camargue, Provence, France
-  acceptance_rate:
-  num_submission:
+  acceptance_rate: null
+  num_submission: null
   general_chair: Sabine Coquillart, Bernd Fröhlich, Daniel Keefe,  Susumu Tachi
-  program_chair: Tobias Höllerer, Victoria Interrante, Anatole Lécuyer, J. Edward Swan II
-
-
+  program_chair: Tobias Höllerer, Victoria Interrante, Anatole Lécuyer, J. Edward
+    Swan II
+  series_link: https://www.vr.org/

--- a/scripts/update_confs_llm.py
+++ b/scripts/update_confs_llm.py
@@ -1,0 +1,205 @@
+import os
+import yaml
+import requests
+from bs4 import BeautifulSoup
+from fake_useragent import UserAgent
+import google.generativeai as genai
+from dotenv import load_dotenv
+import json
+import re
+import time
+
+# Load environment variables
+load_dotenv()
+GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
+
+if not GEMINI_API_KEY:
+    print("Error: GEMINI_API_KEY not found in .env file.")
+    exit(1)
+
+# Configure Gemini
+genai.configure(api_key=GEMINI_API_KEY)
+model = genai.GenerativeModel('gemini-2.0-flash')
+
+DATA_FILE = "public/data/conferences.yaml"
+OUTPUT_FILE = "suggested_updates_llm.yaml"
+
+def load_conferences():
+    with open(DATA_FILE, 'r') as f:
+        return yaml.safe_load(f)
+
+def get_headers():
+    ua = UserAgent()
+    return {'User-Agent': ua.random}
+
+def fetch_html(url):
+    try:
+        print(f"  Fetching {url}...")
+        response = requests.get(url, headers=get_headers(), timeout=15)
+        response.raise_for_status()
+        return response.text
+    except Exception as e:
+        print(f"  Failed to fetch {url}: {e}")
+        return None
+
+def find_next_year_link(series_url, current_year):
+    html = fetch_html(series_url)
+    if not html:
+        return None
+    
+    soup = BeautifulSoup(html, 'html.parser')
+    next_year = int(current_year) + 1
+    short_year = str(next_year)[-2:]
+    
+    # Unwanted patterns that indicate non-conference pages
+    BAD_PATTERNS = [
+        'proceeding', 'archive', 'past-conferences',
+        '.pdf', '.png', '.jpg', '.jpeg', '.gif',  # File extensions
+        'journal', 'submission/', 'volumes-and-issues',  # Journals
+        'flyer', 'poster', 'workshop',  # Supporting materials
+        '/member', '/login', '/subscribe'  # Admin pages
+    ]
+    
+    # Look for links containing the next year
+    for a in soup.find_all('a', href=True):
+        text = a.get_text().strip()
+        href = a['href']
+        
+        # Skip bad patterns
+        if any(pattern in href.lower() for pattern in BAD_PATTERNS):
+            continue
+
+        # Check if year is in text or href (full year or short year in href)
+        is_match = False
+        if str(next_year) in text or str(next_year) in href:
+            is_match = True
+        elif f"-{short_year}" in href or f"/{short_year}" in href or f"{short_year}.html" in href:
+            # Safety check: If we matched a short year (e.g. "27"), 
+            # ensure we didn't just match a different 4-digit year (e.g. "2013" in "aaai-27-2013")
+            # Regex to find any 4-digit year in the href
+            years_in_href = re.findall(r'\d{4}', href)
+            if years_in_href:
+                # If there are years, and none of them is our target next_year, it's likely an old link
+                if str(next_year) not in years_in_href:
+                    is_match = False
+                else:
+                    is_match = True
+            else:
+                is_match = True
+            
+        if is_match:
+            # Resolve relative URLs
+            if not href.startswith('http'):
+                from urllib.parse import urljoin
+                href = urljoin(series_url, href)
+            return href
+            
+    return None
+
+def extract_data_with_llm(html_content, conference_name, year):
+    print(f"  Asking Gemini to extract data for {conference_name} {year}...")
+    
+    # Reduce HTML size by keeping only body and stripping scripts/styles
+    soup = BeautifulSoup(html_content, 'html.parser')
+    for script in soup(["script", "style", "svg", "footer", "nav"]):
+        script.decompose()
+    text = soup.get_text(separator=' ', strip=True)[:20000] # Limit context window
+    
+    prompt = f"""
+    You are a data extraction assistant. Extract the following details for the conference "{conference_name}" taking place in {year} from the text below.
+    
+    Return ONLY a valid JSON object with these keys:
+    - date: The main conference dates (e.g., "2026-05-15" or "May 15-19, 2026").
+    - place: The city and country (e.g., "San Francisco, USA").
+    - deadline: The main paper submission deadline (YYYY-MM-DD if possible, otherwise raw string).
+    - abstract_deadline: The abstract submission deadline (optional).
+    
+    If a field is not found, set it to null.
+    
+    Text:
+    {text}
+    """
+    
+    try:
+        response = model.generate_content(prompt)
+        # Clean up response (remove markdown code blocks if present)
+        content = response.text.strip()
+        if content.startswith("```json"):
+            content = content[7:]
+        if content.endswith("```"):
+            content = content[:-3]
+        
+        return json.loads(content)
+    except Exception as e:
+        print(f"  LLM Extraction failed: {e}")
+        return None
+
+def main():
+    confs = load_conferences()
+    suggestions = []
+    processed_names = set()
+
+    for conf in confs:
+        if not isinstance(conf, dict): continue
+        
+        name = conf.get('name')
+        series_link = conf.get('series_link')
+        year = conf.get('year')
+        
+        # Only process if we have a series link and haven't processed this conf yet
+        if not series_link or name in processed_names:
+            continue
+            
+        processed_names.add(name)
+        print(f"Processing {name}...")
+        
+        # 1. Find next year's URL
+        next_year = int(year) + 1
+        next_url = find_next_year_link(series_link, year)
+        
+        if next_url:
+            print(f"  Found next URL: {next_url}")
+            
+            # 2. Fetch content
+            html = fetch_html(next_url)
+            if html:
+                data = extract_data_with_llm(html, name, next_year)
+                if data:
+                    print(f"  Extracted: {data}")
+                    
+                    # Get description from the current entry
+                    description = conf.get('description', '')
+                    
+                    # Flatten to match conferences.yaml format
+                    suggestion = {
+                        'name': name,
+                        'description': description,
+                        'year': next_year,
+                        'link': next_url,
+                        'deadline': data.get('deadline'),
+                        'abstract_deadline': data.get('abstract_deadline'),
+                        'notification_date': None,
+                        'date': data.get('date'),
+                        'place': data.get('place'),
+                        'acceptance_rate': None,
+                        'num_submission': None,
+                        'general_chair': None,
+                        'program_chair': None
+                    }
+                    suggestions.append(suggestion)
+                    
+                # Sleep to avoid rate limits
+                time.sleep(2)
+        else:
+            print(f"  Could not find link for {next_year} on {series_link}")
+
+    # Save suggestions
+    if suggestions:
+        print(f"Found {len(suggestions)} suggestions. Saving to {OUTPUT_FILE}...")
+        with open(OUTPUT_FILE, 'w') as f:
+            yaml.dump(suggestions, f)
+    else:
+        print("No new updates found.")
+
+if __name__ == "__main__":
+    main()

--- a/suggested_updates_llm.yaml
+++ b/suggested_updates_llm.yaml
@@ -1,0 +1,106 @@
+- abstract_deadline: null
+  acceptance_rate: null
+  date: "July 2\u20137, 2026"
+  deadline: null
+  description: Annual Conference of the North American Chapter of the Association
+    for Computational Linguistics
+  general_chair: null
+  link: https://2026.aclweb.org
+  name: NAACL
+  notification_date: null
+  num_submission: null
+  place: San Diego, California, United States
+  program_chair: null
+  year: 2026
+- abstract_deadline: null
+  acceptance_rate: null
+  date: June 13-19, 2027
+  deadline: null
+  description: ACM SIGMOD International Conference on Management of Data
+  general_chair: null
+  link: https://2027.sigmod.org/
+  name: SIGMOD
+  notification_date: null
+  num_submission: null
+  place: Huntington Beach, California, United States
+  program_chair: null
+  year: 2027
+- abstract_deadline: null
+  acceptance_rate: null
+  date: October 26-30, 2025
+  deadline: null
+  description: IEEE/ACM International Conference on Computer-Aided Design
+  general_chair: null
+  link: https://2025.iccad.com/
+  name: ICCAD
+  notification_date: null
+  num_submission: null
+  place: Munich, Germany
+  program_chair: null
+  year: 2025
+- abstract_deadline: null
+  acceptance_rate: null
+  date: June 8-12, 2026
+  deadline: null
+  description: ACM SIGMETRICS / IFIP Performance Conference
+  general_chair: null
+  link: http://www.sigmetrics.org/sigmetrics2026/
+  name: SIGMETRICS
+  notification_date: null
+  num_submission: null
+  place: Ann Arbor, Michigan, USA
+  program_chair: null
+  year: 2026
+- abstract_deadline: null
+  acceptance_rate: null
+  date: Sat 31 January - Wed 4 February 2026
+  deadline: null
+  description: IEEE/ACM International Symposium on Code Generation and Optimization
+  general_chair: null
+  link: https://2026.cgo.org
+  name: CGO
+  notification_date: null
+  num_submission: null
+  place: Sydney, Australia
+  program_chair: null
+  year: 2026
+- abstract_deadline: null
+  acceptance_rate: null
+  date: "19\u201323 July 2026"
+  deadline: 15 January 2026
+  description: ACM Conference on Computer Graphics and Interactive Techniques
+  general_chair: null
+  link: https://s2026.siggraph.org/
+  name: SIGGRAPH
+  notification_date: null
+  num_submission: null
+  place: Los Angeles, California
+  program_chair: null
+  year: 2026
+- abstract_deadline: null
+  acceptance_rate: null
+  date: "1 \u2013 4 December 2026"
+  deadline: null
+  description: ACM SIGGRAPH Conference and Exhibition on Computer Graphics and Interactive
+    Techniques in Asia
+  general_chair: null
+  link: https://asia.siggraph.org/2025/about-the-event/siggraph-asia-2026/
+  name: SIGGRAPH Asia
+  notification_date: null
+  num_submission: null
+  place: KLCC, Kuala Lumpur, Malaysia
+  program_chair: null
+  year: 2026
+- abstract_deadline: March 24, 2026
+  acceptance_rate: null
+  date: "November 2\u20135, 2026"
+  deadline: March 31, 2026
+  description: ACM Symposium on User Interface Software and Technology
+  general_chair: null
+  link: https://uist.acm.org/2026/
+  name: UIST
+  notification_date: null
+  num_submission: null
+  place: Detroit, MI
+  program_chair: null
+  year: 2026


### PR DESCRIPTION
## Overview
Implemented an LLM-based crawler to automatically discover new conferences.

## Changes
- Implemented scripts/update_confs_llm.py using Google Gemini API
- Added series_link field to 537 conference entries
- Coverage: 41 major conferences (AAAI, CVPR, ICML, NeurIPS, etc.)
- Added filters to prevent false positives
- Test run found 8 new conferences
- See Progress_update.md for notes