### PR TITLE
Add support for rolling monthly deadlines

### DIFF
--- a/public/data/conferences.yaml
+++ b/public/data/conferences.yaml
@@ -4416,10 +4416,12 @@
   description: International Conference on Very Large Data Bases
   year: 2026
   link: https://vldb.org/2026/
-  deadline: '2026-03-01'
-  note: Rolling monthly deadlines until March 2026
-  abstract_deadline: null
-  notification_date: '2026-03-15'
+  rolling_deadline:
+    submission_day: 1
+    notification_day: 15
+    notification_month_offset: 1
+    start: '2025-04-01'
+    end: '2026-03-01'
   date: '2026-08-31'
   place: Boston, MA
   acceptance_rate: null
@@ -4429,10 +4431,12 @@
   description: International Conference on Very Large Data Bases
   year: 2025
   link: https://vldb.org/2025/
-  deadline: '2025-03-01'
-  note: Rolling monthly deadlines until March 2025
-  abstract_deadline: null
-  notification_date: '2025-03-15'
+  rolling_deadline:
+    submission_day: 1
+    notification_day: 15
+    notification_month_offset: 1
+    start: '2024-04-01'
+    end: '2025-03-01'
   date: '2025-09-01'
   place: London, UK
   acceptance_rate: null


### PR DESCRIPTION
## Summary

Add support for conferences with rolling monthly deadlines (e.g., VLDB) without requiring separate YAML entries for each month. 

Github Issue: [#36](https://github.com/dynaroars/csconfs/issues/36)

## Changes

### New `rolling_deadline` YAML schema
Conferences with recurring monthly deadlines can now use a compact configuration:

```yaml
- name: VLDB
  year: 2026
  rolling_deadline:
    submission_day: 1           # Submit on 1st of each month
    notification_day: 15        # Notification on 15th
    notification_month_offset: 1  # of the next month
    start: "2025-04-01"         # First deadline
    end: "2026-03-01"           # Final deadline
  date: "2026-08-31"
  place: Boston, MA
```

### Code changes
- Add `expandRollingDeadlines()` function in `FetchConferences.js` to expand rolling deadlines into individual calendar entries
- Each cycle generates its own deadline and notification date
- Updated VLDB 2025/2026 entries to use the new schema

## Benefits
- Cleaner YAML: 1 entry instead of 12 for VLDB
- Calendar displays all monthly deadlines automatically
- Easy to add other conferences with rolling deadlines

## Test plan

- [x] VLDB deadlines appear on 1st of each month (Apr 2025 - Mar 2026)
- [x] VLDB notifications appear on 15th of following month
- [x] Other conferences still display correctly
- [x] App compiles without errors