### PR TITLE
Fixing the date for the EuroSys 2026 conference

### DIFF
--- a/public/data/conferences.yaml
+++ b/public/data/conferences.yaml
@@ -7015,7 +7015,7 @@
   deadline: '2025-05-15'
   abstract_deadline: '2025-05-08'
   notification_date: '2025-08-22'
-  date: '2026-03-13'
+  date: '2026-04-27'
   place: Edinburgh, Scotland
   note: Cycle 1/2
   acceptance_rate: null
@@ -7031,7 +7031,7 @@
   abstract_deadline: '2025-09-18'
   notification_date: '2026-01-30'
   rebuttal_date: '2026-01-09'
-  date: '2026-03-13'
+  date: '2026-04-27'
   place: Edinburgh, Scotland
   note: Cycle 2/2
   acceptance_rate: null


### PR DESCRIPTION
The date was wrong. Fixing it as per the info here: https://2026.eurosys.org/