### PR TITLE
changed error in readme (npm run start) to (npm run dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npm install
 2. **Run the local server**:
 
 ```bash
-npm run start
+npm run dev
 ```
 
 3. **View in browser**:


### PR DESCRIPTION
Original Readme.md tells us to run the command "npm run start" whereas the project seems to be set up to be run using "npm run dev". New people trying to run their clone might have difficulties.